### PR TITLE
修复本地开发安装setup:engines哈希值预期不一致导致安装报错

### DIFF
--- a/engines/manifest.json
+++ b/engines/manifest.json
@@ -7,14 +7,14 @@
       "requestedSeries": "8.1",
       "actualVersion": "n8.1.2-44-g7c533d0f86-20260821",
       "distribution": "BtbN win64 LGPL shared 8.1",
-      "sourceUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.1-latest-win64-lgpl-shared-8.1.zip",
-      "archiveSha256": "134D6B5A73239F676F283CB745C8CEAE754450731FA07529DDC0AA19A2CA8152",
+      "sourceUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-21-13-40/ffmpeg-n8.1.2-44-g7c533d0f86-win64-lgpl-shared-8.1.zip",
+      "archiveSha256": "e30201900132c0e3da178c63c7dac65aa0a0dcd971779546ae964b86b47bd499",
       "license": "LGPL-2.1-or-later; GPL/nonfree codecs disabled",
       "licenseFiles": [
         "licenses/FFmpeg-LGPL-2.1.txt"
       ],
       "install": {
-        "archiveName": "ffmpeg-n8.1-latest-win64-lgpl-shared-8.1.zip",
+        "archiveName": "ffmpeg-n8.1.2-44-g7c533d0f86-win64-lgpl-shared-8.1.zip",
         "destination": "engines/ffmpeg",
         "anchorFile": "ffmpeg.exe",
         "rootFromAnchorParent": 0

--- a/licenses/THIRD_PARTY_NOTICES.txt
+++ b/licenses/THIRD_PARTY_NOTICES.txt
@@ -8,14 +8,14 @@ transitive dependencies such as Qt, Boost, Ceres, or their dependencies.
 
 FFmpeg / FFprobe
 ----------------
-Version/build: n8.1.2-34-g9b6c8969e0-20260812
+Version/build: n8.1.2-44-g7c533d0f86-20260821
 Distribution: BtbN win64 LGPL shared 8.1
 License: GNU Lesser General Public License v2.1 or later
 SPDX identifier: LGPL-2.1-or-later
 License text: licenses/FFmpeg-LGPL-2.1.txt
 Upstream source: https://ffmpeg.org/download.html
 Build source and scripts: https://github.com/BtbN/FFmpeg-Builds
-Release archive: https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.1-latest-win64-lgpl-shared-8.1.zip
+Release archive: https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-21-13-40/ffmpeg-n8.1.2-44-g7c533d0f86-win64-lgpl-shared-8.1.zip
 
 The selected shared build disables GPL and nonfree components. The complete
 configure string can be inspected with `ffmpeg.exe -buildconf`.

--- a/scripts/verify-licenses.mjs
+++ b/scripts/verify-licenses.mjs
@@ -111,6 +111,15 @@ for (const engine of manifest.engines) {
   assertContains(thirdParty, expected.file, "THIRD_PARTY_NOTICES.txt");
 }
 
+const windowsFfmpeg = manifest.engines.find((engine) => engine.name === "FFmpeg / FFprobe");
+assert(windowsFfmpeg, "Windows FFmpeg manifest entry is missing.");
+assert(
+  !windowsFfmpeg.sourceUrl?.includes("/latest/"),
+  "Windows FFmpeg source URL must reference an immutable release asset, not /latest/.",
+);
+assertContains(thirdParty, windowsFfmpeg.actualVersion, "THIRD_PARTY_NOTICES.txt");
+assertContains(thirdParty, windowsFfmpeg.sourceUrl, "THIRD_PARTY_NOTICES.txt");
+
 const linuxManifest = JSON.parse(readText("engines/manifest.linux.json"));
 assert(linuxManifest.schemaVersion >= 2, "Linux engine manifest schemaVersion must include license mappings.");
 assert(linuxManifest.brush?.version === "0.3.0", "Linux Brush version is incorrect.");

--- a/scripts/verify-licenses.ps1
+++ b/scripts/verify-licenses.ps1
@@ -127,6 +127,12 @@ foreach ($engine in $manifest.engines) {
     Assert-Contains $thirdParty $expected.File "THIRD_PARTY_NOTICES.txt"
 }
 
+$windowsFfmpeg = @($manifest.engines | Where-Object { $_.name -eq "FFmpeg / FFprobe" })
+Assert-True ($windowsFfmpeg.Count -eq 1) "Windows FFmpeg manifest entry is missing or duplicated."
+Assert-True (-not $windowsFfmpeg[0].sourceUrl.Contains("/latest/")) "Windows FFmpeg source URL must reference an immutable release asset, not /latest/."
+Assert-Contains $thirdParty $windowsFfmpeg[0].actualVersion "THIRD_PARTY_NOTICES.txt"
+Assert-Contains $thirdParty $windowsFfmpeg[0].sourceUrl "THIRD_PARTY_NOTICES.txt"
+
 $linuxManifest = (Read-Utf8Text "engines/manifest.linux.json") | ConvertFrom-Json
 Assert-True ($linuxManifest.schemaVersion -ge 2) "Linux engine manifest schemaVersion must include license mappings."
 Assert-True ($linuxManifest.brush.version -eq "0.3.0") "Linux Brush version is incorrect."


### PR DESCRIPTION
Running `npm run setup:engines` on Windows failed because the rolling FFmpeg `latest` asset no longer matched the SHA-256 locked in the engine manifest.

This PR pins FFmpeg / FFprobe to the immutable BtbN `autobuild-2026-08-21-13-40` archive, synchronizes the third-party notice, and adds license checks that reject `/latest/` URLs and manifest/notice drift.

Verified with:
- `npm run verify:engines:windows`
- `npm run verify:licenses`
- `npm run verify:licenses:windows`
- `npm test`
- `npm run build`

Closes #16