### PR TITLE
fix(dev): make the documented checks pass on a fresh clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,6 @@ engines/colmap/**
 engines/brush/**
 !engines/brush/README.md
 engines/linux/brush/**
+!engines/linux/brush/README.md
 engines/macos/arm64/**
+!engines/macos/arm64/README.md

--- a/engines/linux/brush/README.md
+++ b/engines/linux/brush/README.md
@@ -1,0 +1,7 @@
+Brush v0.3.0 Ubuntu x86_64 runtime. `npm run setup:engines:linux` downloads and
+verifies `brush_app` into this directory; the binary itself is never committed.
+
+This README is tracked so the directory exists in a fresh clone.
+`src-tauri/tauri.linux.conf.json` declares the directory as a bundle resource,
+and the Tauri build script aborts when a declared resource path is missing --
+which would otherwise make `cargo test` fail before compiling any test.

--- a/engines/macos/arm64/README.md
+++ b/engines/macos/arm64/README.md
@@ -1,0 +1,8 @@
+Apple Silicon macOS runtime. `npm run setup:engines:macos` downloads and verifies
+the arm64 FFmpeg/FFprobe/COLMAP/Brush closure into `bin/` and `lib/`; the
+binaries themselves are never committed.
+
+This README is tracked so the directory exists in a fresh clone.
+`src-tauri/tauri.macos.conf.json` declares the directory as a bundle resource,
+and the Tauri build script aborts when a declared resource path is missing --
+which would otherwise make `cargo test` fail before compiling any test.

--- a/scripts/setup-engines-macos.sh
+++ b/scripts/setup-engines-macos.sh
@@ -54,6 +54,13 @@ runtime_root="$temporary/ooosplat-engines-macos-arm64"
 
 staged="$temporary/runtime"
 mv "$runtime_root" "$staged"
+# The destination contains a tracked placeholder README so a fresh clone has the
+# resource directory before engines are installed. Preserve it across the
+# all-at-once runtime replacement; otherwise setup leaves the worktree dirty by
+# deleting a tracked file.
+if [[ -f "$destination/README.md" ]]; then
+  cp "$destination/README.md" "$staged/README.md"
+fi
 rm -rf -- "$destination"
 mv "$staged" "$destination"
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -461,9 +461,9 @@ pub async fn begin_gaussian_video_export(
     let (root, _, _) = catalog::registered_final_ply_for_project(project_id).await?;
 
     let active = state.active.lock().await;
-    if !active
+    if active
         .as_ref()
-        .is_some_and(|session| session.project_id == project_id)
+        .is_none_or(|session| session.project_id != project_id)
     {
         return Err(SplatError::Process(
             "该项目当前未在 OOOSplat 预览中打开，无法导出视频。".into(),

--- a/src-tauri/src/engines/health.rs
+++ b/src-tauri/src/engines/health.rs
@@ -834,7 +834,15 @@ mod tests {
         let paths = EnginePaths::from_root("/opt/ooosplat-engines");
         assert_eq!(paths.colmap, PathBuf::from("/opt/ooosplat-engines/colmap"));
         let discovered = EnginePaths::from_candidates(PathBuf::from("/missing/engines"));
-        assert!(discovered.ffmpeg.is_file());
+        // FFmpeg is not installed on every contributor machine or CI runner, so assert
+        // the resolver contract instead of requiring the binary: an explicit override
+        // wins, then PATH, and otherwise the managed path is kept so engine health can
+        // report the exact file it expected.
+        let expected = std::env::var_os("OOOSPLAT_FFMPEG")
+            .map(PathBuf::from)
+            .or_else(|| find_on_path("ffmpeg"))
+            .unwrap_or_else(|| PathBuf::from("/missing/engines/ffmpeg"));
+        assert_eq!(discovered.ffmpeg, expected);
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/process/mod.rs
+++ b/src-tauri/src/process/mod.rs
@@ -475,7 +475,44 @@ mod tests {
         let pid = descendant_pid.lock().unwrap().expect("descendant PID");
         manager.cancel();
         assert!(matches!(run.await.unwrap(), Err(SplatError::Cancelled)));
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        assert!(!PathBuf::from(format!("/proc/{pid}")).exists());
+
+        let mut terminated = false;
+        for _ in 0..150 {
+            if descendant_is_terminated(pid) {
+                terminated = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(
+            terminated,
+            "descendant {pid} was still running after cancellation"
+        );
+    }
+
+    /// A killed descendant is reparented to PID 1, and PID 1 does not reap in every
+    /// container, so the process can linger as a zombie with its `/proc` entry intact.
+    /// The entry being gone and the entry being a zombie both mean the process stopped
+    /// running, which is what cancellation has to guarantee.
+    #[cfg(target_os = "linux")]
+    fn descendant_is_terminated(pid: u32) -> bool {
+        let Ok(status) = std::fs::read_to_string(format!("/proc/{pid}/status")) else {
+            return true;
+        };
+        status
+            .lines()
+            .find_map(|line| line.strip_prefix("State:"))
+            .map(|state| state.trim_start().starts_with('Z'))
+            .unwrap_or(true)
+    }
+
+    /// Unix targets without `/proc` reap orphans through PID 1, so a terminated
+    /// descendant disappears outright rather than lingering as a visible zombie.
+    #[cfg(all(unix, not(target_os = "linux")))]
+    fn descendant_is_terminated(pid: u32) -> bool {
+        // SAFETY: signal 0 only runs the existence and permission checks for the PID
+        // and delivers nothing, so no process state is observed or modified.
+        let alive = unsafe { libc::kill(pid as libc::pid_t, 0) } == 0;
+        !alive
     }
 }


### PR DESCRIPTION
CONTRIBUTING asks contributors to run `cargo test`, `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings`, and none of the three passes on a clean checkout today. `cargo test` never reaches a test on Linux or macOS: the Tauri build script aborts when a declared bundle resource path is missing, and `src-tauri/tauri.linux.conf.json` and `src-tauri/tauri.macos.conf.json` declare `engines/linux/brush/` and `engines/macos/arm64/`, which are gitignored and therefore absent until `setup:engines` downloads binaries into them, so a fresh clone fails with ``resource path `../engines/linux/brush` doesn't exist`` before compiling anything; CI never sees this because it installs the engines first, so it only bites new contributors. This PR tracks a README in each of those two directories, following the convention already used for `engines/ffmpeg`, `engines/colmap` and `engines/brush`, so the directories survive a clone while the binaries stay out of Git. Once the build runs, two tests fail for reasons unrelated to the code under test: `linux_root_is_flat_and_discovery_can_fall_back_to_path` asserts `discovered.ffmpeg.is_file()`, which requires FFmpeg on PATH and is not stated as a prerequisite anywhere, so it now asserts the resolver contract instead — an explicit `OOOSPLAT_FFMPEG` override wins, then PATH, and otherwise the managed path is kept so engine health can report the exact file it expected — covering the same behaviour on a host with or without FFmpeg; and `cancellation_terminates_descendant_processes` asserts that `/proc/{pid}` no longer exists, but a killed descendant is reparented to PID 1 and PID 1 does not reap in every container, so the process correctly stops running yet lingers as a zombie with its `/proc` entry intact and the assertion fails, which is what happens in a plain container today. It now asserts termination directly: on Linux the entry is gone or the state is `Z`, and on other Unix targets signal 0 reports no such process. Worth flagging that the old assertion was also vacuous on macOS, where `/proc` never exists and `exists()` is always false, so that test asserted nothing there; the new one does assert, and while the reasoning holds — the orphaned `sleep` is reparented to launchd and reaped promptly, well inside the bounded three-second poll that replaces the previous fixed 50ms sleep — I have no macOS machine to confirm it on, so please do watch the macOS workflow on this PR. Finally, `cargo clippy --all-targets -- -D warnings` fails on current stable Rust at `reserve_gaussian_video_export` in `src-tauri/src/commands/mod.rs` with `clippy::nonminimal_bool`; the workflows install Rust with an unpinned `rustup update stable`, so this turns the Ubuntu and macOS workflows red as runners pick the toolchain up, and it is fixed here because otherwise this PR could not show a green run either. Verified on Ubuntu 24.04 x86_64 with Rust 1.94.1: `cargo test` 68 passed / 0 failed (66 passed / 2 failed before), `cargo fmt -- --check` clean, `cargo clippy --all-targets -- -D warnings` clean, `npm test` 48 passed, `tsc -b` clean. The fresh-clone claim was checked end to end by cloning the branch into an empty directory and running `cargo test` with no `mkdir` and no `setup:engines`: 68 passed. No pipeline stage was exercised — this change touches only test assertions, two tracked placeholder READMEs, a `.gitignore` negation and one boolean expression, and does not touch FFmpeg, COLMAP, Brush or PLY output.