### PR TITLE
feat: resume interrupted pipelines and improve progress estimates

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -225,6 +225,57 @@ pub async fn start_pipeline(
 }
 
 #[tauri::command]
+pub async fn resume_pipeline(
+    app: tauri::AppHandle,
+    state: State<'_, PipelineController>,
+    telemetry: State<'_, TelemetryService>,
+    project_id: String,
+) -> std::result::Result<PipelineResult, SplatError> {
+    let project_id = parse_project_id(&project_id)?;
+    let (_, metadata) = catalog::load_registered_project(project_id).await?;
+    let emitter = app.clone();
+    let started = Instant::now();
+    let telemetry_session = Arc::new(PipelineTelemetrySession::new(
+        telemetry.inner().clone(),
+        metadata.quality,
+    ));
+    let event_telemetry = telemetry_session.clone();
+    let runner = Arc::new(PipelineRunner::new(paths_for_app(&app), move |event| {
+        event_telemetry.observe(&event);
+        let _ = emitter.emit("pipeline-event", event);
+    }));
+    {
+        let mut active = state.active.lock().await;
+        if active.is_some() {
+            return Err(SplatError::Process("已有任务正在运行".into()));
+        }
+        *active = Some(runner.clone());
+    }
+    telemetry_session.generation_started();
+    let result = runner.resume(project_id).await;
+    match &result {
+        Ok(output) => telemetry_session.generation_completed(
+            output.duration_ms,
+            output.input_images,
+            output.source_duration_seconds,
+        ),
+        Err(error) => telemetry_session.generation_failed(error),
+    }
+    if let Err(error) = &result {
+        let stage = if matches!(error, SplatError::Cancelled) {
+            crate::pipeline::PipelineStage::Cancelled
+        } else {
+            crate::pipeline::PipelineStage::Failed
+        };
+        let mut event = crate::pipeline::PipelineEvent::mapped(stage, 1.0, error.to_string());
+        event.elapsed_ms = started.elapsed().as_millis() as u64;
+        let _ = app.emit("pipeline-event", event);
+    }
+    *state.active.lock().await = None;
+    result
+}
+
+#[tauri::command]
 pub async fn cancel_pipeline(state: State<'_, PipelineController>) -> Result<()> {
     if let Some(runner) = state.active.lock().await.as_ref() {
         runner.cancel();

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     project::{
         catalog::{self, AppSettings, ProjectOverview},
         manager::atomic_write_json,
-        GaussianTransform, ProjectStatus,
+        GaussianTransform, PipelineStateFile, ProjectStatus,
     },
     reconstruction::{ply::inspect_gaussian_ply, splat_transform::export_transformed_ply},
     telemetry::{PipelineTelemetrySession, TelemetryPreferences, TelemetryService},
@@ -143,6 +143,66 @@ pub async fn probe_and_plan(
         plan,
         estimate,
     })
+}
+
+fn resume_checkpoint_fraction(state: &PipelineStateFile) -> (f64, &'static str) {
+    if state.brush_complete {
+        (0.98, "结果发布")
+    } else if state.reconstruction_complete {
+        (0.60, "Brush 训练")
+    } else if state.matching_complete {
+        (0.45, "相机重建")
+    } else if state.features_complete {
+        (0.32, "顺序匹配")
+    } else if state
+        .frames
+        .as_ref()
+        .and_then(|frames| frames.extracted_frames)
+        .is_some_and(|count| count > 0)
+    {
+        (0.20, "特征提取")
+    } else {
+        (0.0, "画面提取")
+    }
+}
+
+#[tauri::command]
+pub async fn estimate_project_runtime(
+    app: tauri::AppHandle,
+    project_id: Uuid,
+) -> Result<RuntimeEstimate> {
+    let (project, metadata) = catalog::load_registered_project(project_id).await?;
+    let state_bytes = tokio::fs::read(project.join("state.json")).await?;
+    let state: PipelineStateFile = serde_json::from_slice(&state_bytes)?;
+    let video = match state.video.clone() {
+        Some(video) => video,
+        None => probe_video(&paths_for_app(&app).ffprobe, &metadata.source_path, None).await?,
+    };
+    let plan = match state.frames.as_ref() {
+        Some(frames) => FramePlan {
+            retention_ratio: frames.retention_ratio,
+            sampling_fps: frames.sampling_fps,
+            estimated_frames: frames
+                .extracted_frames
+                .unwrap_or(frames.estimated_frames)
+                .max(1),
+        },
+        None => UniformRatioFrameSelection.create_plan(&video, &metadata.quality.preset()),
+    };
+    let samples = catalog::runtime_samples().await;
+    let mut estimate = estimate_runtime(&video, &plan, metadata.quality, &samples);
+    let previous_duration = metadata.duration_ms.unwrap_or(0);
+    let (completed_fraction, next_stage) = resume_checkpoint_fraction(&state);
+    let remaining_fraction = 1.0 - completed_fraction;
+    let remaining = |total: u64| ((total as f64 * remaining_fraction).round() as u64).max(1_000);
+    estimate.estimated_ms = previous_duration.saturating_add(remaining(estimate.estimated_ms));
+    estimate.lower_bound_ms = previous_duration.saturating_add(remaining(estimate.lower_bound_ms));
+    estimate.upper_bound_ms = previous_duration.saturating_add(remaining(estimate.upper_bound_ms));
+    estimate.basis = format!(
+        "{}；已计入此前耗时，预计从{next_stage}阶段继续",
+        estimate.basis
+    );
+    Ok(estimate)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -16,7 +16,10 @@ use crate::{
         ColmapAccelerationStatus, EnginePaths, EngineStatus,
     },
     error::{Result, SplatError},
-    pipeline::runner::{PipelineResult, PipelineRunner},
+    pipeline::{
+        estimate::{estimate_runtime, RuntimeEstimate},
+        runner::{PipelineResult, PipelineRunner},
+    },
     presets::Quality,
     project::{
         catalog::{self, AppSettings, ProjectOverview},
@@ -107,6 +110,7 @@ pub struct GaussianVideoExportResult {
 pub struct ProbeAndPlan {
     video: VideoInfo,
     plan: FramePlan,
+    estimate: RuntimeEstimate,
 }
 
 fn paths_for_app(app: &tauri::AppHandle) -> EnginePaths {
@@ -129,9 +133,16 @@ pub async fn probe_and_plan(
     path: String,
     quality: Quality,
 ) -> std::result::Result<ProbeAndPlan, SplatError> {
-    let video = probe_video(&paths_for_app(&app).ffprobe, &PathBuf::from(path), None).await?;
+    let engine_paths = paths_for_app(&app);
+    let video = probe_video(&engine_paths.ffprobe, &PathBuf::from(path), None).await?;
     let plan = UniformRatioFrameSelection.create_plan(&video, &quality.preset());
-    Ok(ProbeAndPlan { video, plan })
+    let samples = catalog::runtime_samples().await;
+    let estimate = estimate_runtime(&video, &plan, quality, &samples);
+    Ok(ProbeAndPlan {
+        video,
+        plan,
+        estimate,
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/engines/ffmpeg.rs
+++ b/src-tauri/src/engines/ffmpeg.rs
@@ -164,7 +164,7 @@ async fn ensure_clean_output(frames: &Path, masks: &Path) -> Result<()> {
     Ok(())
 }
 
-async fn validate_extraction(
+pub(crate) async fn validate_extraction(
     frames: &Path,
     masks: &Path,
     has_alpha: bool,

--- a/src-tauri/src/engines/health.rs
+++ b/src-tauri/src/engines/health.rs
@@ -67,6 +67,8 @@ pub struct GpuDeviceInfo {
     pub name: String,
     pub driver_version: String,
     pub compute_capability: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_memory_mb: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -747,7 +749,7 @@ async fn probe_gpu_devices() -> std::result::Result<Vec<GpuDeviceInfo>, ProbeErr
         manager.run(ProcessSpec {
             executable: candidate,
             args: vec![
-                OsString::from("--query-gpu=index,name,driver_version,compute_cap"),
+                OsString::from("--query-gpu=index,name,driver_version,compute_cap,memory.total"),
                 OsString::from("--format=csv,noheader,nounits"),
             ],
             working_directory: None,
@@ -768,7 +770,7 @@ fn parse_nvidia_smi_csv(output: &str) -> std::result::Result<Vec<GpuDeviceInfo>,
     let mut devices = Vec::new();
     for line in output.lines().filter(|line| !line.trim().is_empty()) {
         let fields = line.split(',').map(str::trim).collect::<Vec<_>>();
-        if fields.len() < 4 {
+        if fields.len() < 5 {
             return Err(ProbeError::InvalidOutput);
         }
         let index = fields[0]
@@ -776,9 +778,10 @@ fn parse_nvidia_smi_csv(output: &str) -> std::result::Result<Vec<GpuDeviceInfo>,
             .map_err(|_| ProbeError::InvalidOutput)?;
         devices.push(GpuDeviceInfo {
             index,
-            name: fields[1..fields.len() - 2].join(", "),
-            driver_version: fields[fields.len() - 2].to_string(),
-            compute_capability: fields[fields.len() - 1].to_string(),
+            name: fields[1..fields.len() - 3].join(", "),
+            driver_version: fields[fields.len() - 3].to_string(),
+            compute_capability: fields[fields.len() - 2].to_string(),
+            total_memory_mb: fields[fields.len() - 1].parse().ok(),
         });
     }
     if devices.is_empty() {
@@ -868,18 +871,31 @@ mod tests {
             name: format!("GPU {index}"),
             driver_version: driver.into(),
             compute_capability: compute.into(),
+            total_memory_mb: Some(8_192),
         }
     }
 
     #[test]
     fn parses_nvidia_smi_csv() {
         let devices = parse_nvidia_smi_csv(
-            "0, NVIDIA GeForce RTX 3060 Ti, 560.81, 8.6\n1, NVIDIA RTX 4090, 560.81, 8.9\n",
+            "0, NVIDIA GeForce RTX 3060 Ti, 560.81, 8.6, 8192\n1, NVIDIA RTX 4090, 560.81, 8.9, 24564\n",
         )
         .unwrap();
         assert_eq!(devices.len(), 2);
         assert_eq!(devices[0].name, "NVIDIA GeForce RTX 3060 Ti");
         assert_eq!(devices[1].compute_capability, "8.9");
+        assert_eq!(devices[0].total_memory_mb, Some(8_192));
+    }
+
+    #[test]
+    fn unavailable_memory_does_not_hide_a_compatible_gpu() {
+        let devices =
+            parse_nvidia_smi_csv("0, NVIDIA GeForce RTX 3060 Ti, 560.81, 8.6, N/A\n").unwrap();
+        assert_eq!(devices[0].total_memory_mb, None);
+        assert_eq!(
+            choose_acceleration(devices, requirements()).backend,
+            ColmapBackend::Gpu
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,7 @@ pub fn run_app() {
             commands::check_colmap_acceleration,
             commands::probe_and_plan,
             commands::start_pipeline,
+            commands::resume_pipeline,
             commands::cancel_pipeline,
             commands::export_ply,
             commands::get_project_overview,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ pub fn run_app() {
             commands::check_engines,
             commands::check_colmap_acceleration,
             commands::probe_and_plan,
+            commands::estimate_project_runtime,
             commands::start_pipeline,
             commands::resume_pipeline,
             commands::cancel_pipeline,

--- a/src-tauri/src/pipeline/estimate.rs
+++ b/src-tauri/src/pipeline/estimate.rs
@@ -7,7 +7,6 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub struct RuntimeSample {
-    pub video: VideoInfo,
     pub quality: Quality,
     pub extracted_frames: u64,
     pub duration_ms: u64,
@@ -38,13 +37,37 @@ pub fn estimate_runtime(
     quality: Quality,
     samples: &[RuntimeSample],
 ) -> RuntimeEstimate {
-    let base = base_estimate_ms(video, plan.estimated_frames, quality);
-    let mut calibration = samples
+    let base = base_estimate_ms(plan.estimated_frames, quality);
+    let valid_samples = samples
         .iter()
         .filter(|sample| sample.duration_ms >= 10_000 && sample.extracted_frames > 0)
+        .collect::<Vec<_>>();
+    let same_quality = valid_samples
+        .iter()
+        .copied()
+        .filter(|sample| sample.quality == quality)
+        .collect::<Vec<_>>();
+    let nearby_same_quality = same_quality
+        .iter()
+        .copied()
+        .filter(|sample| {
+            let smaller = sample.extracted_frames.min(plan.estimated_frames).max(1) as f64;
+            let larger = sample.extracted_frames.max(plan.estimated_frames).max(1) as f64;
+            larger / smaller <= 1.25
+        })
+        .collect::<Vec<_>>();
+    let (calibration_source, calibration_label) = if !nearby_same_quality.is_empty() {
+        (nearby_same_quality, "同档位、相近帧数")
+    } else if !same_quality.is_empty() {
+        (same_quality, "同档位")
+    } else {
+        (valid_samples, "跨档位")
+    };
+    let mut calibration = calibration_source
+        .into_iter()
         .map(|sample| {
-            let expected = base_estimate_ms(&sample.video, sample.extracted_frames, sample.quality);
-            (sample.duration_ms as f64 / expected.max(1) as f64).clamp(0.60, 2.50)
+            let expected = base_estimate_ms(sample.extracted_frames, sample.quality);
+            (sample.duration_ms as f64 / expected.max(1) as f64).clamp(0.15, 5.0)
         })
         .collect::<Vec<_>>();
     calibration.sort_by(f64::total_cmp);
@@ -64,27 +87,54 @@ pub fn estimate_runtime(
         confidence,
         sample_count,
         basis: if sample_count == 0 {
-            "根据视频分辨率、抽帧数和质量档位估算；完成任务后会自动校准".into()
+            format!(
+                "根据输入 {} 总帧、预计处理 {} 帧和质量档位估算；完成任务后会自动校准",
+                video.total_frames, plan.estimated_frames
+            )
         } else {
-            format!("根据视频分辨率、抽帧数、质量档位和本机 {sample_count} 个已完成任务校准")
+            format!(
+                "根据输入 {} 总帧、预计处理 {} 帧、质量档位和本机 {sample_count} 个{calibration_label}任务校准",
+                video.total_frames, plan.estimated_frames,
+            )
         },
     }
 }
 
-fn base_estimate_ms(video: &VideoInfo, frames: u64, quality: Quality) -> u64 {
-    let preset = quality.preset();
-    let megapixels = video.width as f64 * video.height as f64 / 1_000_000.0;
-    let pixel_factor = (megapixels / 2.0736).sqrt().clamp(0.65, 1.8);
+fn base_estimate_ms(frames: u64, quality: Quality) -> u64 {
     let frame_count = frames.max(1) as f64;
 
     // Feature work grows roughly linearly with frames and pixels, while camera
     // reconstruction and bundle adjustment grow faster as more views are added.
-    let preparation_ms = 8_000.0 + frame_count * 55.0 * pixel_factor;
+    let preparation_ms = 8_000.0 + frame_count * 55.0;
     let reconstruction_ms = 176.0 * frame_count.powf(1.5);
+    let brush_ms = estimate_brush_stage_ms(quality) as f64;
+    (preparation_ms + reconstruction_ms + brush_ms).round() as u64
+}
+
+/// Brush v0.3.0 does not expose its current training step on stdout/stderr.
+/// This duration model is therefore used only to provide a clearly labelled,
+/// best-effort progress indicator while the process is alive.
+pub(crate) fn estimate_brush_stage_ms(quality: Quality) -> u64 {
+    let preset = quality.preset();
     let resolution_factor = (preset.brush_max_resolution as f64 / 960.0).powf(1.35);
     let iteration_factor = preset.brush_iterations as f64 / 6_000.0;
-    let brush_ms = 80_000.0 * resolution_factor * iteration_factor;
-    (preparation_ms + reconstruction_ms + brush_ms).round() as u64
+    (80_000.0 * resolution_factor * iteration_factor)
+        .round()
+        .max(1_000.0) as u64
+}
+
+pub(crate) fn estimate_calibrated_brush_stage_ms(
+    video: &VideoInfo,
+    plan: &FramePlan,
+    quality: Quality,
+    samples: &[RuntimeSample],
+) -> u64 {
+    let base_total_ms = base_estimate_ms(plan.estimated_frames, quality).max(1);
+    let calibrated_total_ms = estimate_runtime(video, plan, quality, samples).estimated_ms;
+    let calibration = calibrated_total_ms as f64 / base_total_ms as f64;
+    (estimate_brush_stage_ms(quality) as f64 * calibration)
+        .round()
+        .max(1_000.0) as u64
 }
 
 fn median(values: &[f64]) -> Option<f64> {
@@ -115,11 +165,40 @@ mod tests {
 
     #[test]
     fn quality_and_frame_count_increase_the_estimate() {
-        let video = video();
-        let fast = base_estimate_ms(&video, 48, Quality::Fast);
-        let balanced = base_estimate_ms(&video, 72, Quality::Balanced);
-        let high = base_estimate_ms(&video, 120, Quality::High);
+        let fast = base_estimate_ms(48, Quality::Fast);
+        let balanced = base_estimate_ms(72, Quality::Balanced);
+        let high = base_estimate_ms(120, Quality::High);
         assert!(fast < balanced && balanced < high);
+    }
+
+    #[test]
+    fn brush_stage_estimate_increases_with_the_quality_preset() {
+        assert!(
+            estimate_brush_stage_ms(Quality::Fast) < estimate_brush_stage_ms(Quality::Balanced)
+        );
+        assert!(
+            estimate_brush_stage_ms(Quality::Balanced) < estimate_brush_stage_ms(Quality::High)
+        );
+    }
+
+    #[test]
+    fn brush_stage_estimate_uses_the_same_local_history_calibration() {
+        let video = video();
+        let plan = FramePlan {
+            retention_ratio: 0.5,
+            sampling_fps: 30.0,
+            estimated_frames: 533,
+        };
+        let base_total = base_estimate_ms(plan.estimated_frames, Quality::Balanced);
+        let sample = RuntimeSample {
+            quality: Quality::Balanced,
+            extracted_frames: plan.estimated_frames,
+            duration_ms: base_total * 2,
+        };
+
+        let calibrated =
+            estimate_calibrated_brush_stage_ms(&video, &plan, Quality::Balanced, &[sample]);
+        assert_eq!(calibrated, estimate_brush_stage_ms(Quality::Balanced) * 2);
     }
 
     #[test]
@@ -131,7 +210,6 @@ mod tests {
             estimated_frames: 48,
         };
         let sample = RuntimeSample {
-            video: video.clone(),
             quality: Quality::Fast,
             extracted_frames: 226,
             duration_ms: 858_613,
@@ -146,5 +224,67 @@ mod tests {
         assert_eq!(estimate.sample_count, 3);
         assert!(estimate.lower_bound_ms < estimate.estimated_ms);
         assert!(estimate.upper_bound_ms > estimate.estimated_ms);
+    }
+
+    #[test]
+    fn same_quality_samples_take_priority_and_use_the_median() {
+        let video = video();
+        let plan = FramePlan {
+            retention_ratio: 0.5,
+            sampling_fps: 30.0,
+            estimated_frames: 533,
+        };
+        let samples = [
+            RuntimeSample {
+                quality: Quality::Balanced,
+                extracted_frames: 533,
+                duration_ms: 3_954_000,
+            },
+            RuntimeSample {
+                quality: Quality::Fast,
+                extracted_frames: 320,
+                duration_ms: 374_000,
+            },
+            RuntimeSample {
+                quality: Quality::High,
+                extracted_frames: 416,
+                duration_ms: 10_464_000,
+            },
+        ];
+        let estimate = estimate_runtime(&video, &plan, Quality::Balanced, &samples);
+        assert_eq!(estimate.sample_count, 1);
+        assert_eq!(estimate.estimated_ms, 3_954_000);
+        assert!(estimate.basis.contains("1 个同档位、相近帧数任务"));
+    }
+
+    #[test]
+    fn nearby_frame_counts_do_not_mix_unrelated_runs() {
+        let video = video();
+        let plan = FramePlan {
+            retention_ratio: 0.3,
+            sampling_fps: 9.0,
+            estimated_frames: 320,
+        };
+        let samples = [
+            RuntimeSample {
+                quality: Quality::Fast,
+                extracted_frames: 320,
+                duration_ms: 840_000,
+            },
+            RuntimeSample {
+                quality: Quality::Fast,
+                extracted_frames: 320,
+                duration_ms: 960_000,
+            },
+            RuntimeSample {
+                quality: Quality::Fast,
+                extracted_frames: 506,
+                duration_ms: 374_000,
+            },
+        ];
+        let estimate = estimate_runtime(&video, &plan, Quality::Fast, &samples);
+        assert_eq!(estimate.sample_count, 2);
+        assert_eq!(estimate.estimated_ms, 900_000);
+        assert!(estimate.basis.contains("相近帧数"));
     }
 }

--- a/src-tauri/src/pipeline/estimate.rs
+++ b/src-tauri/src/pipeline/estimate.rs
@@ -1,0 +1,150 @@
+use serde::Serialize;
+
+use crate::{
+    presets::Quality,
+    video::{FramePlan, VideoInfo},
+};
+
+#[derive(Debug, Clone)]
+pub struct RuntimeSample {
+    pub video: VideoInfo,
+    pub quality: Quality,
+    pub extracted_frames: u64,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EstimateConfidence {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeEstimate {
+    pub estimated_ms: u64,
+    pub lower_bound_ms: u64,
+    pub upper_bound_ms: u64,
+    pub confidence: EstimateConfidence,
+    pub sample_count: usize,
+    pub basis: String,
+}
+
+pub fn estimate_runtime(
+    video: &VideoInfo,
+    plan: &FramePlan,
+    quality: Quality,
+    samples: &[RuntimeSample],
+) -> RuntimeEstimate {
+    let base = base_estimate_ms(video, plan.estimated_frames, quality);
+    let mut calibration = samples
+        .iter()
+        .filter(|sample| sample.duration_ms >= 10_000 && sample.extracted_frames > 0)
+        .map(|sample| {
+            let expected = base_estimate_ms(&sample.video, sample.extracted_frames, sample.quality);
+            (sample.duration_ms as f64 / expected.max(1) as f64).clamp(0.60, 2.50)
+        })
+        .collect::<Vec<_>>();
+    calibration.sort_by(f64::total_cmp);
+    let sample_count = calibration.len();
+    let factor = median(&calibration).unwrap_or(1.0);
+    let estimated_ms = (base as f64 * factor).round().max(1_000.0) as u64;
+    let (confidence, lower_factor, upper_factor) = match sample_count {
+        0 => (EstimateConfidence::Low, 0.55, 1.75),
+        1..=2 => (EstimateConfidence::Low, 0.60, 1.60),
+        3..=5 => (EstimateConfidence::Medium, 0.72, 1.38),
+        _ => (EstimateConfidence::High, 0.82, 1.22),
+    };
+    RuntimeEstimate {
+        estimated_ms,
+        lower_bound_ms: (estimated_ms as f64 * lower_factor).round() as u64,
+        upper_bound_ms: (estimated_ms as f64 * upper_factor).round() as u64,
+        confidence,
+        sample_count,
+        basis: if sample_count == 0 {
+            "根据视频分辨率、抽帧数和质量档位估算；完成任务后会自动校准".into()
+        } else {
+            format!("根据视频分辨率、抽帧数、质量档位和本机 {sample_count} 个已完成任务校准")
+        },
+    }
+}
+
+fn base_estimate_ms(video: &VideoInfo, frames: u64, quality: Quality) -> u64 {
+    let preset = quality.preset();
+    let megapixels = video.width as f64 * video.height as f64 / 1_000_000.0;
+    let pixel_factor = (megapixels / 2.0736).sqrt().clamp(0.65, 1.8);
+    let frame_count = frames.max(1) as f64;
+
+    // Feature work grows roughly linearly with frames and pixels, while camera
+    // reconstruction and bundle adjustment grow faster as more views are added.
+    let preparation_ms = 8_000.0 + frame_count * 55.0 * pixel_factor;
+    let reconstruction_ms = 176.0 * frame_count.powf(1.5);
+    let resolution_factor = (preset.brush_max_resolution as f64 / 960.0).powf(1.35);
+    let iteration_factor = preset.brush_iterations as f64 / 6_000.0;
+    let brush_ms = 80_000.0 * resolution_factor * iteration_factor;
+    (preparation_ms + reconstruction_ms + brush_ms).round() as u64
+}
+
+fn median(values: &[f64]) -> Option<f64> {
+    match values.len() {
+        0 => None,
+        length if length % 2 == 1 => Some(values[length / 2]),
+        length => Some((values[length / 2 - 1] + values[length / 2]) / 2.0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn video() -> VideoInfo {
+        VideoInfo {
+            duration: 12.52,
+            width: 3840,
+            height: 2160,
+            fps: 60.0,
+            total_frames: 752,
+            codec: "hevc".into(),
+            rotation: 0,
+            pixel_format: "yuv420p".into(),
+            has_alpha: false,
+        }
+    }
+
+    #[test]
+    fn quality_and_frame_count_increase_the_estimate() {
+        let video = video();
+        let fast = base_estimate_ms(&video, 48, Quality::Fast);
+        let balanced = base_estimate_ms(&video, 72, Quality::Balanced);
+        let high = base_estimate_ms(&video, 120, Quality::High);
+        assert!(fast < balanced && balanced < high);
+    }
+
+    #[test]
+    fn completed_local_runs_calibrate_and_narrow_the_range() {
+        let video = video();
+        let plan = FramePlan {
+            retention_ratio: 0.064,
+            sampling_fps: 3.83,
+            estimated_frames: 48,
+        };
+        let sample = RuntimeSample {
+            video: video.clone(),
+            quality: Quality::Fast,
+            extracted_frames: 226,
+            duration_ms: 858_613,
+        };
+        let estimate = estimate_runtime(
+            &video,
+            &plan,
+            Quality::Fast,
+            &[sample.clone(), sample.clone(), sample],
+        );
+        assert_eq!(estimate.confidence, EstimateConfidence::Medium);
+        assert_eq!(estimate.sample_count, 3);
+        assert!(estimate.lower_bound_ms < estimate.estimated_ms);
+        assert!(estimate.upper_bound_ms > estimate.estimated_ms);
+    }
+}

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -1,3 +1,4 @@
+pub mod estimate;
 pub mod event;
 pub mod progress;
 pub mod runner;

--- a/src-tauri/src/pipeline/runner.rs
+++ b/src-tauri/src/pipeline/runner.rs
@@ -1119,6 +1119,99 @@ mod tests {
             .is_none());
     }
 
+    #[tokio::test]
+    async fn transparent_frame_checkpoint_requires_matching_masks() {
+        let temporary = tempfile::tempdir().unwrap();
+        let paths = ProjectPaths::existing(uuid::Uuid::nil(), temporary.path().to_path_buf());
+        tokio::fs::create_dir_all(&paths.frames).await.unwrap();
+        tokio::fs::create_dir_all(&paths.masks).await.unwrap();
+        tokio::fs::write(paths.frames.join("frame_000001.png"), b"rgba")
+            .await
+            .unwrap();
+        tokio::fs::write(paths.masks.join("frame_000001.png.png"), b"mask")
+            .await
+            .unwrap();
+        let mut state = PipelineStateFile::created(Quality::Balanced);
+        state.video = Some(VideoInfo {
+            duration: 1.0,
+            width: 1920,
+            height: 1080,
+            fps: 30.0,
+            total_frames: 30,
+            codec: "prores".into(),
+            rotation: 0,
+            pixel_format: "yuva444p10le".into(),
+            has_alpha: true,
+        });
+        state.frames = Some(FrameState {
+            retention_ratio: 0.5,
+            sampling_fps: 15.0,
+            estimated_frames: 1,
+            extracted_frames: Some(1),
+            image_format: Some("png".into()),
+            mask_count: Some(1),
+            has_alpha: true,
+        });
+
+        let prepared = prepared_frames_from_checkpoint(&paths, &state)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(prepared.has_alpha);
+        assert_eq!(prepared.mask_count, 1);
+
+        tokio::fs::remove_file(paths.masks.join("frame_000001.png.png"))
+            .await
+            .unwrap();
+        assert!(prepared_frames_from_checkpoint(&paths, &state)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn empty_colmap_database_downgrades_the_feature_checkpoint() {
+        let temporary = tempfile::tempdir().unwrap();
+        let paths = ProjectPaths::existing(uuid::Uuid::nil(), temporary.path().to_path_buf());
+        tokio::fs::create_dir_all(&paths.frames).await.unwrap();
+        tokio::fs::create_dir_all(&paths.colmap).await.unwrap();
+        tokio::fs::write(paths.frames.join("frame_000001.jpg"), b"jpeg")
+            .await
+            .unwrap();
+        tokio::fs::write(paths.colmap.join("database.db"), b"")
+            .await
+            .unwrap();
+        let mut state = PipelineStateFile::created(Quality::Balanced);
+        state.video = Some(VideoInfo {
+            duration: 1.0,
+            width: 1920,
+            height: 1080,
+            fps: 30.0,
+            total_frames: 30,
+            codec: "h264".into(),
+            rotation: 0,
+            pixel_format: "yuv420p".into(),
+            has_alpha: false,
+        });
+        state.frames = Some(FrameState {
+            retention_ratio: 0.5,
+            sampling_fps: 15.0,
+            estimated_frames: 1,
+            extracted_frames: Some(1),
+            image_format: Some("jpeg".into()),
+            mask_count: Some(0),
+            has_alpha: false,
+        });
+        state.features_complete = true;
+        state.matching_complete = true;
+
+        normalize_checkpoints(&paths, &mut state).await.unwrap();
+
+        assert!(!state.features_complete);
+        assert!(!state.matching_complete);
+        assert_eq!(state.stage, PipelineStage::ExtractingFrames);
+    }
+
     #[test]
     fn parses_colmap_file_progress() {
         assert_eq!(

--- a/src-tauri/src/pipeline/runner.rs
+++ b/src-tauri/src/pipeline/runner.rs
@@ -19,8 +19,8 @@ use crate::{
     },
     error::{Result, SplatError},
     pipeline::{
-        progress::stage_progress_range, EventKind, EventLevel, PipelineEngine, PipelineEvent,
-        PipelineStage,
+        estimate::estimate_calibrated_brush_stage_ms, progress::stage_progress_range, EventKind,
+        EventLevel, PipelineEngine, PipelineEvent, PipelineStage,
     },
     presets::Quality,
     process::{ProcessManager, ProcessObserver, ProcessUpdate},
@@ -622,6 +622,13 @@ impl PipelineRunner {
         } else {
             reset_directory(&paths.brush).await?;
             let dataset = prepare_brush_dataset(&paths.brush, &paths.frames, &model).await?;
+            let runtime_samples = catalog::runtime_samples().await;
+            let estimated_brush_duration_ms = estimate_calibrated_brush_stage_ms(
+                &prepared.video,
+                &prepared.plan,
+                quality,
+                &runtime_samples,
+            );
             self.events.send(
                 PipelineStage::TrainingSplats,
                 Some(PipelineEngine::Brush),
@@ -630,8 +637,10 @@ impl PipelineRunner {
                 None,
                 true,
                 format!(
-                    "Brush 训练开始（使用可用图形后端）· {} iterations · 最大分辨率 {}",
-                    preset.brush_iterations, preset.brush_max_resolution
+                    "Brush 训练开始（使用可用图形后端）· {} iterations · 最大分辨率 {} · 预计约 {}",
+                    preset.brush_iterations,
+                    preset.brush_max_resolution,
+                    format_duration(estimated_brush_duration_ms)
                 ),
                 Some(0),
                 Some(preset.brush_iterations as u64),
@@ -648,7 +657,9 @@ impl PipelineRunner {
                     PipelineStage::TrainingSplats,
                     PipelineEngine::Brush,
                     Some(preset.brush_iterations as u64),
-                    ObserverMode::Brush,
+                    ObserverMode::Brush {
+                        estimated_duration_ms: estimated_brush_duration_ms,
+                    },
                 )),
             )
             .await?;
@@ -725,6 +736,7 @@ impl PipelineRunner {
     ) -> ProcessObserver {
         let events = self.events.clone();
         let mapper_count = Arc::new(AtomicU64::new(0));
+        let brush_progress_basis_points = Arc::new(AtomicU64::new(0));
         Arc::new(move |update| match update {
             ProcessUpdate::Started { process_id } => events.send(
                 stage,
@@ -738,19 +750,32 @@ impl PipelineRunner {
                 expected_total,
                 None,
             ),
-            ProcessUpdate::Heartbeat { elapsed_ms } if mode == ObserverMode::Brush => events.send(
-                stage,
-                Some(engine),
-                EventKind::Heartbeat,
-                EventLevel::Info,
-                None,
-                true,
-                format!("Brush 正在运行 · 已用时 {}", format_duration(elapsed_ms)),
-                None,
-                expected_total,
-                Some("iterations"),
-            ),
-            ProcessUpdate::Heartbeat { .. } => {}
+            ProcessUpdate::Heartbeat { elapsed_ms } => {
+                if let ObserverMode::Brush {
+                    estimated_duration_ms,
+                } = mode
+                {
+                    let progress = estimated_brush_progress(elapsed_ms, estimated_duration_ms);
+                    brush_progress_basis_points
+                        .store((progress * 10_000.0).round() as u64, Ordering::Relaxed);
+                    events.send(
+                        stage,
+                        Some(engine),
+                        EventKind::Heartbeat,
+                        EventLevel::Info,
+                        Some(progress),
+                        false,
+                        format!(
+                            "Brush 训练中 · 估算进度 {:.0}% · 已用时 {}",
+                            progress * 100.0,
+                            format_duration(elapsed_ms)
+                        ),
+                        None,
+                        expected_total,
+                        Some("estimated_progress"),
+                    );
+                }
+            }
             ProcessUpdate::Line { stream: _, line } => {
                 if line.is_empty() {
                     return;
@@ -771,7 +796,7 @@ impl PipelineRunner {
                     ObserverMode::Mapper => {
                         parse_mapper_progress(&line, &mapper_count, expected_total)
                     }
-                    ObserverMode::Brush => None,
+                    ObserverMode::Brush { .. } => None,
                 };
                 if let Some((current, total, message)) = parsed {
                     let progress = total
@@ -789,7 +814,22 @@ impl PipelineRunner {
                         total,
                         Some("张"),
                     );
-                } else if mode == ObserverMode::Brush || is_useful_line(&line) {
+                } else if matches!(mode, ObserverMode::Brush { .. }) {
+                    let progress =
+                        brush_progress_basis_points.load(Ordering::Relaxed) as f32 / 10_000.0;
+                    events.send(
+                        stage,
+                        Some(engine),
+                        EventKind::Log,
+                        EventLevel::Info,
+                        Some(progress),
+                        progress == 0.0,
+                        friendly_engine_line(&line),
+                        None,
+                        expected_total,
+                        Some("estimated_progress"),
+                    );
+                } else if is_useful_line(&line) {
                     events.send(
                         stage,
                         Some(engine),
@@ -813,7 +853,16 @@ enum ObserverMode {
     Ffmpeg,
     BracketProgress,
     Mapper,
-    Brush,
+    Brush { estimated_duration_ms: u64 },
+}
+
+fn estimated_brush_progress(elapsed_ms: u64, estimated_duration_ms: u64) -> f32 {
+    const MAX_PROGRESS_BEFORE_COMPLETION: f64 = 0.95;
+    if estimated_duration_ms == 0 {
+        return 0.0;
+    }
+    ((elapsed_ms as f64 / estimated_duration_ms as f64) * MAX_PROGRESS_BEFORE_COMPLETION)
+        .clamp(0.0, MAX_PROGRESS_BEFORE_COMPLETION) as f32
 }
 
 fn parse_ffmpeg_frame(line: &str) -> Option<u64> {
@@ -1234,6 +1283,19 @@ mod tests {
         )
         .unwrap();
         assert_eq!(value.0, 86);
+    }
+
+    #[test]
+    fn brush_estimated_progress_advances_and_stops_at_ninety_five_percent() {
+        assert_eq!(estimated_brush_progress(0, 100_000), 0.0);
+        assert!((estimated_brush_progress(50_000, 100_000) - 0.475).abs() < f32::EPSILON);
+        assert!((estimated_brush_progress(100_000, 100_000) - 0.95).abs() < f32::EPSILON);
+        assert!((estimated_brush_progress(500_000, 100_000) - 0.95).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn brush_estimated_progress_handles_an_invalid_duration() {
+        assert_eq!(estimated_brush_progress(10_000, 0), 0.0);
     }
 
     #[test]

--- a/src-tauri/src/pipeline/runner.rs
+++ b/src-tauri/src/pipeline/runner.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use crate::{
     engines::{
         brush, colmap,
-        ffmpeg::{extract_uniform_frames, FrameImageFormat},
+        ffmpeg::{extract_uniform_frames, validate_extraction, FrameImageFormat},
         ffprobe::probe_video,
         EngineKind, EnginePaths,
     },
@@ -25,7 +25,7 @@ use crate::{
     presets::Quality,
     process::{ProcessManager, ProcessObserver, ProcessUpdate},
     project::{
-        FrameState, PipelineStateFile, ProjectManager, ProjectMetadata, ProjectOutput,
+        catalog, FrameState, PipelineStateFile, ProjectManager, ProjectMetadata, ProjectOutput,
         ProjectPaths, ProjectStatus,
     },
     reconstruction::{
@@ -340,15 +340,57 @@ impl PipelineRunner {
         let acceleration = self.verify_pipeline_engines().await?;
         self.events.acceleration(acceleration.clone());
         let (paths, mut metadata) = project_manager.create(input, quality).await?;
+        let state = PipelineStateFile::created(quality);
+        self.execute_project(project_manager, paths, &mut metadata, state, &acceleration)
+            .await
+    }
+
+    pub async fn resume(&self, project_id: uuid::Uuid) -> Result<PipelineResult> {
+        let acceleration = self.verify_pipeline_engines().await?;
+        self.events.acceleration(acceleration.clone());
+        let (project, mut metadata) = catalog::load_registered_project(project_id).await?;
+        if metadata.status == ProjectStatus::Completed || project.join("final.ply").is_file() {
+            return Err(SplatError::Process("该项目已经完成，无需继续".into()));
+        }
+        if !metadata.source_path.is_file() {
+            return Err(SplatError::Process("项目源视频缺失，无法继续".into()));
+        }
+        let paths = ProjectPaths::existing(project_id, project.clone());
+        let project_manager = ProjectManager::with_root(
+            project
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| project.clone()),
+        );
+        let state = project_manager.read_state(&paths.state).await?;
+        if state.preset != metadata.quality {
+            return Err(SplatError::Process(
+                "项目档位与检查点不一致，无法安全继续".into(),
+            ));
+        }
+        self.execute_project(project_manager, paths, &mut metadata, state, &acceleration)
+            .await
+    }
+
+    async fn execute_project(
+        &self,
+        project_manager: ProjectManager,
+        paths: ProjectPaths,
+        metadata: &mut ProjectMetadata,
+        state: PipelineStateFile,
+        acceleration: &crate::engines::ColmapAccelerationStatus,
+    ) -> Result<PipelineResult> {
         let started = Instant::now();
+        let previous_duration = metadata.duration_ms.unwrap_or(0);
+        metadata.status = ProjectStatus::Running;
+        metadata.started_at = Some(Utc::now());
+        metadata.completed_at = None;
+        metadata.failure_message = None;
+        project_manager
+            .write_metadata(&paths.metadata, metadata)
+            .await?;
         let result = self
-            .run_project(
-                &project_manager,
-                &paths,
-                &mut metadata,
-                quality,
-                &acceleration,
-            )
+            .run_project(&project_manager, &paths, metadata, state, acceleration)
             .await;
 
         if let Err(error) = &result {
@@ -359,12 +401,16 @@ impl PipelineRunner {
                 ProjectStatus::Failed
             };
             metadata.completed_at = Some(Utc::now());
-            metadata.duration_ms = Some(started.elapsed().as_millis() as u64);
+            metadata.duration_ms =
+                Some(previous_duration.saturating_add(started.elapsed().as_millis() as u64));
             metadata.failure_message = Some(error.to_string());
             let _ = project_manager
-                .write_metadata(&paths.metadata, &metadata)
+                .write_metadata(&paths.metadata, metadata)
                 .await;
-            let mut state = PipelineStateFile::created(quality);
+            let mut state = project_manager
+                .read_state(&paths.state)
+                .await
+                .unwrap_or_else(|_| PipelineStateFile::created(metadata.quality));
             state.stage = if cancelled {
                 PipelineStage::Cancelled
             } else {
@@ -380,29 +426,50 @@ impl PipelineRunner {
         project_manager: &ProjectManager,
         paths: &ProjectPaths,
         metadata: &mut ProjectMetadata,
-        quality: Quality,
+        mut state: PipelineStateFile,
         acceleration: &crate::engines::ColmapAccelerationStatus,
     ) -> Result<PipelineResult> {
-        let mut state = PipelineStateFile::created(quality);
-        let prepared = self
-            .prepare_frames(
-                &metadata.source_path,
-                quality,
-                &paths.frames,
-                &paths.masks,
-                Some(&paths.logs),
-            )
-            .await?;
-        let source_duration_seconds = prepared.video.duration;
-        state.video = Some(prepared.video);
-        let mut frames = FrameState::from(&prepared.plan);
-        frames.extracted_frames = Some(prepared.extracted_frames);
-        frames.image_format = Some(prepared.image_format.as_str().into());
-        frames.mask_count = Some(prepared.mask_count);
-        frames.has_alpha = prepared.has_alpha;
-        state.frames = Some(frames);
-        state.stage = PipelineStage::ExtractingFrames;
+        let quality = metadata.quality;
+        normalize_checkpoints(paths, &mut state).await?;
         project_manager.write_state(&paths.state, &state).await?;
+        let prepared =
+            if let Some(prepared) = prepared_frames_from_checkpoint(paths, &state).await? {
+                self.events.stage(
+                    PipelineStage::ExtractingFrames,
+                    1.0,
+                    format!("已复用 {} 帧检查点", prepared.extracted_frames),
+                );
+                prepared
+            } else {
+                reset_directory(&paths.frames).await?;
+                reset_directory(&paths.masks).await?;
+                reset_directory(&paths.colmap).await?;
+                reset_directory(&paths.brush).await?;
+                let prepared = self
+                    .prepare_frames(
+                        &metadata.source_path,
+                        quality,
+                        &paths.frames,
+                        &paths.masks,
+                        Some(&paths.logs),
+                    )
+                    .await?;
+                state.video = Some(prepared.video.clone());
+                let mut frames = FrameState::from(&prepared.plan);
+                frames.extracted_frames = Some(prepared.extracted_frames);
+                frames.image_format = Some(prepared.image_format.as_str().into());
+                frames.mask_count = Some(prepared.mask_count);
+                frames.has_alpha = prepared.has_alpha;
+                state.frames = Some(frames);
+                state.features_complete = false;
+                state.matching_complete = false;
+                state.reconstruction_complete = false;
+                state.brush_complete = false;
+                state.stage = PipelineStage::ExtractingFrames;
+                project_manager.write_state(&paths.state, &state).await?;
+                prepared
+            };
+        let source_duration_seconds = prepared.video.duration;
 
         let database = paths.colmap.join("database.db");
         let sparse = paths.colmap.join("sparse");
@@ -416,83 +483,103 @@ impl PipelineRunner {
 
         let backend_label = if acceleration.use_gpu() { "GPU" } else { "CPU" };
         let gpu_index = acceleration.gpu_index();
-        self.events.stage(
-            PipelineStage::ExtractingFeatures,
-            0.0,
-            format!("COLMAP 正在使用 {backend_label} 提取特征"),
-        );
-        colmap::extract_features(
-            &self.engines.colmap,
-            &database,
-            colmap_images,
-            colmap_masks,
-            colmap_log.clone(),
-            &self.process_manager,
-            Some(self.process_observer(
+        if state.features_complete {
+            self.events.stage(
                 PipelineStage::ExtractingFeatures,
-                PipelineEngine::Colmap,
-                Some(prepared.extracted_frames),
-                ObserverMode::BracketProgress,
-            )),
-            gpu_index,
-        )
-        .await?;
-        state.stage = PipelineStage::ExtractingFeatures;
-        state.features_complete = true;
-        project_manager.write_state(&paths.state, &state).await?;
-        self.events.stage(
-            PipelineStage::ExtractingFeatures,
-            1.0,
-            format!("{backend_label} 特征提取完成"),
-        );
+                1.0,
+                "已复用特征提取检查点",
+            );
+        } else {
+            reset_directory(&paths.colmap).await?;
+            self.events.stage(
+                PipelineStage::ExtractingFeatures,
+                0.0,
+                format!("COLMAP 正在使用 {backend_label} 提取特征"),
+            );
+            colmap::extract_features(
+                &self.engines.colmap,
+                &database,
+                colmap_images,
+                colmap_masks,
+                colmap_log.clone(),
+                &self.process_manager,
+                Some(self.process_observer(
+                    PipelineStage::ExtractingFeatures,
+                    PipelineEngine::Colmap,
+                    Some(prepared.extracted_frames),
+                    ObserverMode::BracketProgress,
+                )),
+                gpu_index,
+            )
+            .await?;
+            state.stage = PipelineStage::ExtractingFeatures;
+            state.features_complete = true;
+            project_manager.write_state(&paths.state, &state).await?;
+            self.events.stage(
+                PipelineStage::ExtractingFeatures,
+                1.0,
+                format!("{backend_label} 特征提取完成"),
+            );
+        }
 
-        self.events.stage(
-            PipelineStage::Matching,
-            0.0,
-            format!("COLMAP 正在进行 {backend_label} 顺序匹配"),
-        );
-        colmap::match_sequential(
-            &self.engines.colmap,
-            &database,
-            colmap_log.clone(),
-            &self.process_manager,
-            Some(self.process_observer(
+        if state.matching_complete {
+            self.events
+                .stage(PipelineStage::Matching, 1.0, "已复用顺序匹配检查点");
+        } else {
+            self.events.stage(
                 PipelineStage::Matching,
-                PipelineEngine::Colmap,
-                Some(prepared.extracted_frames),
-                ObserverMode::BracketProgress,
-            )),
-            gpu_index,
-        )
-        .await?;
-        state.stage = PipelineStage::Matching;
-        state.matching_complete = true;
-        project_manager.write_state(&paths.state, &state).await?;
-        self.events
-            .stage(PipelineStage::Matching, 1.0, "顺序匹配完成");
+                0.0,
+                format!("COLMAP 正在进行 {backend_label} 顺序匹配"),
+            );
+            colmap::match_sequential(
+                &self.engines.colmap,
+                &database,
+                colmap_log.clone(),
+                &self.process_manager,
+                Some(self.process_observer(
+                    PipelineStage::Matching,
+                    PipelineEngine::Colmap,
+                    Some(prepared.extracted_frames),
+                    ObserverMode::BracketProgress,
+                )),
+                gpu_index,
+            )
+            .await?;
+            state.stage = PipelineStage::Matching;
+            state.matching_complete = true;
+            project_manager.write_state(&paths.state, &state).await?;
+            self.events
+                .stage(PipelineStage::Matching, 1.0, "顺序匹配完成");
+        }
 
-        self.events
-            .stage(PipelineStage::Reconstructing, 0.0, "正在增量重建相机轨迹");
-        colmap::map(
-            &self.engines.colmap,
-            &database,
-            colmap_images,
-            &sparse,
-            colmap_log,
-            &self.process_manager,
-            Some(self.process_observer(
-                PipelineStage::Reconstructing,
-                PipelineEngine::Colmap,
-                Some(prepared.extracted_frames),
-                ObserverMode::Mapper,
-            )),
-        )
-        .await?;
-        state.stage = PipelineStage::Reconstructing;
-        state.reconstruction_complete = true;
-        project_manager.write_state(&paths.state, &state).await?;
-        self.events
-            .stage(PipelineStage::Reconstructing, 1.0, "增量重建完成");
+        if state.reconstruction_complete {
+            self.events
+                .stage(PipelineStage::Reconstructing, 1.0, "已复用相机重建检查点");
+        } else {
+            reset_directory(&sparse).await?;
+            self.events
+                .stage(PipelineStage::Reconstructing, 0.0, "正在增量重建相机轨迹");
+            colmap::map(
+                &self.engines.colmap,
+                &database,
+                colmap_images,
+                &sparse,
+                colmap_log,
+                &self.process_manager,
+                Some(self.process_observer(
+                    PipelineStage::Reconstructing,
+                    PipelineEngine::Colmap,
+                    Some(prepared.extracted_frames),
+                    ObserverMode::Mapper,
+                )),
+            )
+            .await?;
+            state.stage = PipelineStage::Reconstructing;
+            state.reconstruction_complete = true;
+            project_manager.write_state(&paths.state, &state).await?;
+            self.events
+                .stage(PipelineStage::Reconstructing, 1.0, "增量重建完成");
+        }
 
         self.events.stage(
             PipelineStage::ValidatingReconstruction,
@@ -523,43 +610,55 @@ impl PipelineRunner {
             ),
         );
 
-        let dataset = prepare_brush_dataset(&paths.brush, &paths.frames, &model).await?;
         let preset = quality.preset();
-        self.events.send(
-            PipelineStage::TrainingSplats,
-            Some(PipelineEngine::Brush),
-            EventKind::Stage,
-            EventLevel::Info,
-            None,
-            true,
-            format!(
-                "Brush 训练开始（使用可用图形后端）· {} iterations · 最大分辨率 {}",
-                preset.brush_iterations, preset.brush_max_resolution
-            ),
-            Some(0),
-            Some(preset.brush_iterations as u64),
-            Some("iterations"),
-        );
-        let candidate = brush::train(
-            &self.engines.brush,
-            &dataset,
-            &paths.brush,
-            preset,
-            paths.logs.join("brush.log"),
-            &self.process_manager,
-            Some(self.process_observer(
+        let candidate = if state.brush_complete {
+            self.events.stage(
                 PipelineStage::TrainingSplats,
-                PipelineEngine::Brush,
+                1.0,
+                "已复用 Brush 训练检查点",
+            );
+            brush_candidate(&paths.brush)
+                .ok_or_else(|| SplatError::Process("Brush 检查点文件缺失，无法继续发布".into()))?
+        } else {
+            reset_directory(&paths.brush).await?;
+            let dataset = prepare_brush_dataset(&paths.brush, &paths.frames, &model).await?;
+            self.events.send(
+                PipelineStage::TrainingSplats,
+                Some(PipelineEngine::Brush),
+                EventKind::Stage,
+                EventLevel::Info,
+                None,
+                true,
+                format!(
+                    "Brush 训练开始（使用可用图形后端）· {} iterations · 最大分辨率 {}",
+                    preset.brush_iterations, preset.brush_max_resolution
+                ),
+                Some(0),
                 Some(preset.brush_iterations as u64),
-                ObserverMode::Brush,
-            )),
-        )
-        .await?;
-        state.stage = PipelineStage::TrainingSplats;
-        state.brush_complete = true;
-        project_manager.write_state(&paths.state, &state).await?;
-        self.events
-            .stage(PipelineStage::TrainingSplats, 1.0, "Brush 训练完成");
+                Some("iterations"),
+            );
+            let candidate = brush::train(
+                &self.engines.brush,
+                &dataset,
+                &paths.brush,
+                preset,
+                paths.logs.join("brush.log"),
+                &self.process_manager,
+                Some(self.process_observer(
+                    PipelineStage::TrainingSplats,
+                    PipelineEngine::Brush,
+                    Some(preset.brush_iterations as u64),
+                    ObserverMode::Brush,
+                )),
+            )
+            .await?;
+            state.stage = PipelineStage::TrainingSplats;
+            state.brush_complete = true;
+            project_manager.write_state(&paths.state, &state).await?;
+            self.events
+                .stage(PipelineStage::TrainingSplats, 1.0, "Brush 训练完成");
+            candidate
+        };
 
         self.events
             .stage(PipelineStage::Exporting, 0.0, "正在校验并发布 final.ply");
@@ -570,10 +669,12 @@ impl PipelineRunner {
         project_manager.write_state(&paths.state, &state).await?;
 
         let completed_at = Utc::now();
-        let duration_ms = metadata
-            .started_at
-            .map(|started| (completed_at - started).num_milliseconds().max(0) as u64)
-            .unwrap_or(0);
+        let duration_ms = metadata.duration_ms.unwrap_or(0).saturating_add(
+            metadata
+                .started_at
+                .map(|started| (completed_at - started).num_milliseconds().max(0) as u64)
+                .unwrap_or(0),
+        );
         metadata.status = ProjectStatus::Completed;
         metadata.completed_at = Some(completed_at);
         metadata.duration_ms = Some(duration_ms);
@@ -787,6 +888,109 @@ fn format_duration(milliseconds: u64) -> String {
     )
 }
 
+fn checkpoint_stage(state: &PipelineStateFile) -> PipelineStage {
+    if state.brush_complete {
+        PipelineStage::TrainingSplats
+    } else if state.reconstruction_complete {
+        PipelineStage::Reconstructing
+    } else if state.matching_complete {
+        PipelineStage::Matching
+    } else if state.features_complete {
+        PipelineStage::ExtractingFeatures
+    } else if state
+        .frames
+        .as_ref()
+        .and_then(|frames| frames.extracted_frames)
+        .is_some_and(|count| count > 0)
+    {
+        PipelineStage::ExtractingFrames
+    } else {
+        PipelineStage::Created
+    }
+}
+
+async fn normalize_checkpoints(paths: &ProjectPaths, state: &mut PipelineStateFile) -> Result<()> {
+    let frames_complete = prepared_frames_from_checkpoint(paths, state)
+        .await?
+        .is_some();
+    if !frames_complete {
+        state.video = None;
+        state.frames = None;
+    }
+
+    let database_complete = tokio::fs::metadata(paths.colmap.join("database.db"))
+        .await
+        .is_ok_and(|metadata| metadata.is_file() && metadata.len() > 0);
+    state.features_complete = frames_complete && state.features_complete && database_complete;
+    state.matching_complete = state.features_complete && state.matching_complete;
+    state.reconstruction_complete = state.matching_complete
+        && state.reconstruction_complete
+        && best_sparse_model(&paths.frames, &paths.colmap.join("sparse")).is_ok();
+    state.brush_complete = state.reconstruction_complete
+        && state.brush_complete
+        && brush_candidate(&paths.brush)
+            .and_then(|path| inspect_gaussian_ply(&path).ok())
+            .is_some();
+    state.stage = checkpoint_stage(state);
+    Ok(())
+}
+
+async fn prepared_frames_from_checkpoint(
+    paths: &ProjectPaths,
+    state: &PipelineStateFile,
+) -> Result<Option<PreparedFrames>> {
+    let Some(video) = state.video.clone() else {
+        return Ok(None);
+    };
+    let Some(frames) = state.frames.as_ref() else {
+        return Ok(None);
+    };
+    let Some(extracted_frames) = frames.extracted_frames.filter(|count| *count > 0) else {
+        return Ok(None);
+    };
+    let has_alpha = frames.has_alpha || video.has_alpha;
+    let Ok(extraction) = validate_extraction(&paths.frames, &paths.masks, has_alpha).await else {
+        return Ok(None);
+    };
+    if extraction.frame_count != extracted_frames
+        || frames
+            .image_format
+            .as_deref()
+            .is_some_and(|format| format != extraction.image_format.as_str())
+        || frames
+            .mask_count
+            .is_some_and(|count| count != extraction.mask_count)
+    {
+        return Ok(None);
+    }
+    Ok(Some(PreparedFrames {
+        video,
+        plan: FramePlan {
+            retention_ratio: frames.retention_ratio,
+            sampling_fps: frames.sampling_fps,
+            estimated_frames: frames.estimated_frames,
+        },
+        extracted_frames,
+        image_format: extraction.image_format,
+        mask_count: extraction.mask_count,
+        has_alpha: extraction.has_alpha,
+    }))
+}
+
+fn brush_candidate(root: &Path) -> Option<PathBuf> {
+    [root.join("final.ply.tmp"), root.join("final.ply.tmp.ply")]
+        .into_iter()
+        .find(|path| path.is_file())
+}
+
+async fn reset_directory(path: &Path) -> Result<()> {
+    if path.exists() {
+        tokio::fs::remove_dir_all(path).await?;
+    }
+    tokio::fs::create_dir_all(path).await?;
+    Ok(())
+}
+
 fn best_sparse_model(frames: &Path, sparse: &Path) -> Result<(PathBuf, ReconstructionReport)> {
     let mut best: Option<(PathBuf, ReconstructionReport)> = None;
     for entry in std::fs::read_dir(sparse)? {
@@ -843,6 +1047,76 @@ mod tests {
     fn parses_ffmpeg_progress() {
         assert_eq!(parse_ffmpeg_frame("frame=127"), Some(127));
         assert_eq!(parse_ffmpeg_frame("progress=continue"), None);
+    }
+
+    #[test]
+    fn reports_the_latest_durable_checkpoint_instead_of_terminal_status() {
+        let mut state = PipelineStateFile::created(Quality::Balanced);
+        state.stage = PipelineStage::Cancelled;
+        assert_eq!(checkpoint_stage(&state), PipelineStage::Created);
+
+        state.frames = Some(FrameState {
+            retention_ratio: 0.5,
+            sampling_fps: 15.0,
+            estimated_frames: 100,
+            extracted_frames: Some(100),
+            image_format: Some("jpeg".into()),
+            mask_count: Some(0),
+            has_alpha: false,
+        });
+        state.features_complete = true;
+        state.matching_complete = true;
+        assert_eq!(checkpoint_stage(&state), PipelineStage::Matching);
+
+        state.reconstruction_complete = true;
+        state.brush_complete = true;
+        assert_eq!(checkpoint_stage(&state), PipelineStage::TrainingSplats);
+    }
+
+    #[tokio::test]
+    async fn frame_checkpoint_requires_every_recorded_frame() {
+        let temporary = tempfile::tempdir().unwrap();
+        let paths = ProjectPaths::existing(uuid::Uuid::nil(), temporary.path().to_path_buf());
+        tokio::fs::create_dir_all(&paths.frames).await.unwrap();
+        tokio::fs::write(paths.frames.join("frame_000001.jpg"), b"one")
+            .await
+            .unwrap();
+        tokio::fs::write(paths.frames.join("frame_000002.jpg"), b"two")
+            .await
+            .unwrap();
+        let mut state = PipelineStateFile::created(Quality::Balanced);
+        state.video = Some(VideoInfo {
+            duration: 1.0,
+            width: 1920,
+            height: 1080,
+            fps: 30.0,
+            total_frames: 30,
+            codec: "h264".into(),
+            rotation: 0,
+            pixel_format: "yuv420p".into(),
+            has_alpha: false,
+        });
+        state.frames = Some(FrameState {
+            retention_ratio: 0.5,
+            sampling_fps: 15.0,
+            estimated_frames: 2,
+            extracted_frames: Some(2),
+            image_format: Some("jpeg".into()),
+            mask_count: Some(0),
+            has_alpha: false,
+        });
+
+        assert!(prepared_frames_from_checkpoint(&paths, &state)
+            .await
+            .unwrap()
+            .is_some());
+        tokio::fs::remove_file(paths.frames.join("frame_000002.jpg"))
+            .await
+            .unwrap();
+        assert!(prepared_frames_from_checkpoint(&paths, &state)
+            .await
+            .unwrap()
+            .is_none());
     }
 
     #[test]

--- a/src-tauri/src/project/catalog.rs
+++ b/src-tauri/src/project/catalog.rs
@@ -9,9 +9,54 @@ use uuid::Uuid;
 
 use crate::{
     error::{Result, SplatError},
+    pipeline::estimate::RuntimeSample,
     project::{manager::atomic_write_json, ProjectMetadata, ProjectStatus, PROJECT_APP_ID},
     reconstruction::ply::inspect_gaussian_ply,
 };
+
+pub async fn runtime_samples() -> Vec<RuntimeSample> {
+    let Ok(index) = load_index().await else {
+        return Vec::new();
+    };
+    let mut samples = Vec::new();
+    for item in index.projects.into_iter().rev() {
+        let Ok(metadata_bytes) = tokio::fs::read(item.path.join("project.json")).await else {
+            continue;
+        };
+        let Ok(metadata) = serde_json::from_slice::<ProjectMetadata>(&metadata_bytes) else {
+            continue;
+        };
+        let Some(duration_ms) = metadata
+            .duration_ms
+            .filter(|_| metadata.status == ProjectStatus::Completed)
+        else {
+            continue;
+        };
+        let Ok(state_bytes) = tokio::fs::read(item.path.join("state.json")).await else {
+            continue;
+        };
+        let Ok(state) = serde_json::from_slice::<crate::project::PipelineStateFile>(&state_bytes)
+        else {
+            continue;
+        };
+        let (Some(video), Some(frames)) = (state.video, state.frames) else {
+            continue;
+        };
+        let Some(extracted_frames) = frames.extracted_frames.filter(|count| *count > 0) else {
+            continue;
+        };
+        samples.push(RuntimeSample {
+            video,
+            quality: metadata.quality,
+            extracted_frames,
+            duration_ms,
+        });
+        if samples.len() == 20 {
+            break;
+        }
+    }
+    samples
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/project/catalog.rs
+++ b/src-tauri/src/project/catalog.rs
@@ -32,21 +32,14 @@ pub async fn runtime_samples() -> Vec<RuntimeSample> {
         else {
             continue;
         };
-        let Ok(state_bytes) = tokio::fs::read(item.path.join("state.json")).await else {
-            continue;
-        };
-        let Ok(state) = serde_json::from_slice::<crate::project::PipelineStateFile>(&state_bytes)
-        else {
-            continue;
-        };
-        let (Some(video), Some(frames)) = (state.video, state.frames) else {
-            continue;
-        };
-        let Some(extracted_frames) = frames.extracted_frames.filter(|count| *count > 0) else {
+        let state_bytes = tokio::fs::read(item.path.join("state.json")).await.ok();
+        let Some(extracted_frames) = runtime_sample_frame_count(
+            state_bytes.as_deref(),
+            metadata.output.as_ref().map(|output| output.input_images),
+        ) else {
             continue;
         };
         samples.push(RuntimeSample {
-            video,
             quality: metadata.quality,
             extracted_frames,
             duration_ms,
@@ -56,6 +49,21 @@ pub async fn runtime_samples() -> Vec<RuntimeSample> {
         }
     }
     samples
+}
+
+fn runtime_sample_frame_count(
+    state_bytes: Option<&[u8]>,
+    output_frames: Option<u64>,
+) -> Option<u64> {
+    state_bytes
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(bytes).ok())
+        .and_then(|state| {
+            state
+                .pointer("/frames/extractedFrames")
+                .and_then(|value| value.as_u64())
+        })
+        .or(output_frames)
+        .filter(|count| *count > 0)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -435,6 +443,21 @@ mod tests {
         assert!(!serde_json::to_string(&parsed)
             .unwrap()
             .contains("colmapAcceleration"));
+    }
+
+    #[test]
+    fn runtime_samples_fall_back_to_project_output_for_legacy_state() {
+        let legacy_state = br#"{"stage":"completed"}"#;
+        assert_eq!(
+            runtime_sample_frame_count(Some(legacy_state), Some(533)),
+            Some(533)
+        );
+        let current_state = br#"{"frames":{"extractedFrames":320}}"#;
+        assert_eq!(
+            runtime_sample_frame_count(Some(current_state), Some(533)),
+            Some(320)
+        );
+        assert_eq!(runtime_sample_frame_count(None, Some(0)), None);
     }
 
     #[test]

--- a/src-tauri/src/project/manager.rs
+++ b/src-tauri/src/project/manager.rs
@@ -25,6 +25,27 @@ pub struct ProjectPaths {
     pub state: PathBuf,
 }
 
+impl ProjectPaths {
+    pub fn existing(id: Uuid, project: PathBuf) -> Self {
+        let source = project.join("source");
+        let work = project.join("work");
+        Self {
+            id,
+            metadata: project.join("project.json"),
+            output: project.clone(),
+            frames: work.join("frames"),
+            masks: work.join("masks"),
+            colmap: work.join("colmap"),
+            brush: work.join("brush"),
+            logs: project.join("logs"),
+            state: project.join("state.json"),
+            project,
+            source,
+            work,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ProjectManager {
     projects_root: PathBuf,
@@ -149,6 +170,9 @@ impl ProjectManager {
 
     pub async fn write_state(&self, path: &Path, state: &PipelineStateFile) -> Result<()> {
         atomic_write_json(path, state).await
+    }
+    pub async fn read_state(&self, path: &Path) -> Result<PipelineStateFile> {
+        Ok(serde_json::from_slice(&tokio::fs::read(path).await?)?)
     }
     pub async fn write_metadata(&self, path: &Path, metadata: &ProjectMetadata) -> Result<()> {
         atomic_write_json(path, metadata).await

--- a/src/app/App.preview.test.tsx
+++ b/src/app/App.preview.test.tsx
@@ -8,6 +8,8 @@ import { useGaussianTransformStore } from "../stores/gaussianTransformStore";
 import type { ProjectSummary } from "../types/pipeline";
 
 const mocks = vi.hoisted(() => ({
+  cancelPipeline: vi.fn(),
+  estimateProjectRuntime: vi.fn(),
   prepareGaussianPreview: vi.fn(),
   releaseGaussianPreview: vi.fn(),
   resumePipeline: vi.fn(),
@@ -18,9 +20,10 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../lib/backend", () => ({
-  cancelPipeline: vi.fn(),
+  cancelPipeline: mocks.cancelPipeline,
   checkEngines: vi.fn().mockResolvedValue([]),
   confirmAndDeleteProject: vi.fn().mockResolvedValue(false),
+  estimateProjectRuntime: mocks.estimateProjectRuntime,
   getProjectOverview: mocks.getProjectOverview,
   initializeTelemetry: mocks.initializeTelemetry,
   onPipelineEvent: vi.fn().mockResolvedValue(() => undefined),
@@ -87,6 +90,15 @@ describe("App preview workspace", () => {
       latestEvent: null, events: [], result: null, error: null,
     });
     mocks.prepareGaussianPreview.mockReset();
+    mocks.cancelPipeline.mockReset().mockResolvedValue(undefined);
+    mocks.estimateProjectRuntime.mockReset().mockResolvedValue({
+      estimatedMs: 4_000_000,
+      lowerBoundMs: 3_000_000,
+      upperBoundMs: 5_000_000,
+      confidence: "medium",
+      sampleCount: 3,
+      basis: "按同档位历史任务校准",
+    });
     mocks.releaseGaussianPreview.mockReset().mockResolvedValue(undefined);
     mocks.resumePipeline.mockReset().mockResolvedValue({
       projectId: project.id, projectPath: project.projectPath, finalPly: project.finalPly,
@@ -177,6 +189,25 @@ describe("App preview workspace", () => {
     await flush();
 
     expect(mocks.resumePipeline).toHaveBeenCalledWith(project.id);
+    expect(mocks.estimateProjectRuntime).toHaveBeenCalledWith(project.id);
+  });
+
+  it("blocks the interface while a slow cancellation is still terminating processes", async () => {
+    act(() => useAppStore.setState({ phase: "running" }));
+    await flush();
+
+    const cancelButton = [...container.querySelectorAll("button")].find((button) => button.textContent === "取消任务并终止所有进程");
+    await act(async () => { cancelButton?.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    expect(mocks.cancelPipeline).toHaveBeenCalledTimes(1);
+    expect(container.querySelector(".cancellation-backdrop")).toBeNull();
+
+    await act(async () => { await new Promise((resolve) => window.setTimeout(resolve, 350)); });
+    expect(container.querySelector(".cancellation-backdrop")).not.toBeNull();
+    expect(container.textContent).toContain("正在关闭当前阶段及其子进程");
+
+    act(() => useAppStore.setState({ phase: "cancelled" }));
+    await flush();
+    expect(container.querySelector(".cancellation-backdrop")).toBeNull();
   });
 
   it("shows the estimated total generation time after video analysis", async () => {
@@ -204,9 +235,38 @@ describe("App preview workspace", () => {
     }));
     await flush();
 
-    expect(container.textContent).toContain("预计生成");
+    expect(container.textContent).toContain("预计时长");
     expect(container.textContent).toContain("约 2 分 0 秒");
     expect(container.querySelector('[title="本机历史任务校准"]')).not.toBeNull();
+  });
+
+  it("labels Brush heartbeat progress as an estimate", async () => {
+    act(() => useAppStore.setState({
+      phase: "running",
+      progress: 79,
+      progressMessage: "Brush 训练中 · 估算进度 50%",
+      latestEvent: {
+        sequence: 7,
+        timestamp: new Date().toISOString(),
+        kind: "heartbeat",
+        level: "info",
+        stage: "TrainingSplats",
+        engine: "brush",
+        progress: 79,
+        stageProgress: 50,
+        indeterminate: false,
+        message: "Brush 训练中 · 估算进度 50%",
+        current: null,
+        total: 15_000,
+        unit: "estimated_progress",
+        elapsedMs: 120_000,
+        acceleration: null,
+      },
+    }));
+    await flush();
+
+    expect(container.textContent).toContain("估算 50%");
+    expect(container.textContent).not.toContain("15,000 / 15,000");
   });
 
   it("shows only the task panes until a completed project is opened", async () => {

--- a/src/app/App.preview.test.tsx
+++ b/src/app/App.preview.test.tsx
@@ -83,7 +83,7 @@ describe("App preview workspace", () => {
     useGaussianTransformStore.getState().close();
     useAppStore.setState({
       videoPath: null, projectsRoot: "E:\\Projects", projects: [], quality: "balanced", colmapAcceleration: null,
-      video: null, plan: null, engines: [], phase: "idle", progress: 0, progressMessage: "",
+      video: null, plan: null, estimate: null, engines: [], phase: "idle", progress: 0, progressMessage: "",
       latestEvent: null, events: [], result: null, error: null,
     });
     mocks.prepareGaussianPreview.mockReset();
@@ -177,6 +177,36 @@ describe("App preview workspace", () => {
     await flush();
 
     expect(mocks.resumePipeline).toHaveBeenCalledWith(project.id);
+  });
+
+  it("shows the estimated total generation time after video analysis", async () => {
+    act(() => useAppStore.setState({
+      video: {
+        duration: 10,
+        width: 1920,
+        height: 1080,
+        fps: 30,
+        totalFrames: 300,
+        codec: "h264",
+        rotation: 0,
+        pixelFormat: "yuv420p",
+        hasAlpha: false,
+      },
+      plan: { retentionRatio: 0.5, samplingFps: 15, estimatedFrames: 150 },
+      estimate: {
+        estimatedMs: 120_000,
+        lowerBoundMs: 60_000,
+        upperBoundMs: 180_000,
+        confidence: "medium",
+        sampleCount: 3,
+        basis: "本机历史任务校准",
+      },
+    }));
+    await flush();
+
+    expect(container.textContent).toContain("预计生成");
+    expect(container.textContent).toContain("约 2 分 0 秒");
+    expect(container.querySelector('[title="本机历史任务校准"]')).not.toBeNull();
   });
 
   it("shows only the task panes until a completed project is opened", async () => {

--- a/src/app/App.preview.test.tsx
+++ b/src/app/App.preview.test.tsx
@@ -10,6 +10,7 @@ import type { ProjectSummary } from "../types/pipeline";
 const mocks = vi.hoisted(() => ({
   prepareGaussianPreview: vi.fn(),
   releaseGaussianPreview: vi.fn(),
+  resumePipeline: vi.fn(),
   getProjectOverview: vi.fn(),
   initializeTelemetry: vi.fn(),
   setTelemetryConsent: vi.fn(),
@@ -26,6 +27,7 @@ vi.mock("../lib/backend", () => ({
   prepareGaussianPreview: mocks.prepareGaussianPreview,
   probeAndPlan: vi.fn(),
   releaseGaussianPreview: mocks.releaseGaussianPreview,
+  resumePipeline: mocks.resumePipeline,
   revealProject: vi.fn(),
   selectProjectsRoot: vi.fn(),
   selectVideo: vi.fn(),
@@ -86,6 +88,13 @@ describe("App preview workspace", () => {
     });
     mocks.prepareGaussianPreview.mockReset();
     mocks.releaseGaussianPreview.mockReset().mockResolvedValue(undefined);
+    mocks.resumePipeline.mockReset().mockResolvedValue({
+      projectId: project.id, projectPath: project.projectPath, finalPly: project.finalPly,
+      fileSize: project.fileSize, splatCount: project.splatCount, inputImages: 100,
+      registeredImages: 90, registeredRatio: 0.9, points3d: 10_000,
+      durationMs: project.durationMs, completedAt: project.completedAt, warning: null,
+      logsDirectory: `${project.projectPath}\\logs`,
+    });
     mocks.getProjectOverview.mockReset().mockResolvedValue({ projectsRoot: "E:\\Projects", projects: [project] });
     mocks.initializeTelemetry.mockReset().mockResolvedValue({ analyticsEnabled: true, consentDecided: true, deliveryStatus: "configured" });
     mocks.setTelemetryConsent.mockReset().mockResolvedValue({ analyticsEnabled: true, consentDecided: true, deliveryStatus: "configured" });
@@ -157,6 +166,17 @@ describe("App preview workspace", () => {
     }));
     await flush();
     expect(container.textContent).not.toContain("将自动提取透明画面和 COLMAP Mask");
+  });
+
+  it("offers to continue an unfinished project from its checkpoint", async () => {
+    const unfinished = { ...project, status: "cancelled" as const, finalPly: null, completedAt: null };
+    await act(async () => { useAppStore.setState({ projects: [unfinished] }); });
+
+    const resumeButton = [...container.querySelectorAll("button")].find((button) => button.textContent === "继续任务");
+    await act(async () => { resumeButton?.dispatchEvent(new MouseEvent("click", { bubbles: true })); });
+    await flush();
+
+    expect(mocks.resumePipeline).toHaveBeenCalledWith(project.id);
   });
 
   it("shows only the task panes until a completed project is opened", async () => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -13,6 +13,7 @@ import {
   initializeTelemetry, setTelemetryConsent, resumePipeline,
 } from "../lib/backend";
 import { startElapsedTicker } from "../lib/elapsedTimer";
+import { projectRuntime } from "../lib/runtimeEstimate";
 import { useAppStore } from "../stores/appStore";
 import { useGaussianTransformStore } from "../stores/gaussianTransformStore";
 import type { EngineStatus, ProjectStatus, ProjectSummary, Quality } from "../types/pipeline";
@@ -131,6 +132,10 @@ export function App() {
   const completed = useMemo(() => store.projects.filter((project) => project.status === "completed"), [store.projects]);
   const unfinished = useMemo(() => store.projects.filter((project) => project.status !== "completed"), [store.projects]);
   const activeStageIndex = stagePosition(store.latestEvent?.stage);
+  const projectedTiming = useMemo(
+    () => projectRuntime(store.estimate, store.progress, liveElapsedMs, isRunning),
+    [isRunning, liveElapsedMs, store.estimate, store.progress],
+  );
 
   const refreshProjects = async () => {
     const overview = await getProjectOverview();
@@ -224,7 +229,7 @@ export function App() {
     store.setError(null);
     try {
       const result = await probeAndPlan(path, quality);
-      store.setAnalysis(result.video, result.plan);
+      store.setAnalysis(result.video, result.plan, result.estimate);
       store.setPhase("idle");
     } catch (error) {
       store.setError(messageOf(error));
@@ -420,7 +425,7 @@ export function App() {
           <span className="acceleration-icon">{store.colmapAcceleration?.backend === "gpu" ? <Zap size={17} fill="currentColor" /> : store.colmapAcceleration && !["nvidiaSmiNotFound", "noNvidiaGpu", "macOsCpuOnly"].includes(store.colmapAcceleration.reasonCode) ? <CircleAlert size={17} /> : store.colmapAcceleration ? <Cpu size={17} /> : <LoaderCircle className="spin" size={17} />}</span>
           <span>
             <strong>{store.colmapAcceleration == null ? "正在检测 COLMAP GPU 加速…" : store.colmapAcceleration.backend === "gpu" ? "COLMAP GPU 加速已开启" : "COLMAP 使用 CPU"}</strong>
-            <small>{store.colmapAcceleration == null ? "正在读取 COLMAP 加速能力" : store.colmapAcceleration.backend === "gpu" && store.colmapAcceleration.device ? `${store.colmapAcceleration.device.name} · 驱动 ${store.colmapAcceleration.device.driverVersion} · Compute Capability ${store.colmapAcceleration.device.computeCapability}` : store.colmapAcceleration.reasonCode === "macOsCpuOnly" ? store.colmapAcceleration.reason : `${store.colmapAcceleration.reason} · 最低要求：驱动 ${store.colmapAcceleration.requirements.minimumDriverVersion}，Compute Capability ${store.colmapAcceleration.requirements.minimumComputeCapability}`}</small>
+            <small>{store.colmapAcceleration == null ? "正在读取 COLMAP 加速能力" : store.colmapAcceleration.backend === "gpu" && store.colmapAcceleration.device ? `${store.colmapAcceleration.device.name}${store.colmapAcceleration.device.totalMemoryMb ? ` · ${(store.colmapAcceleration.device.totalMemoryMb / 1024).toFixed(1)} GB 显存` : ""} · 驱动 ${store.colmapAcceleration.device.driverVersion} · Compute Capability ${store.colmapAcceleration.device.computeCapability}` : store.colmapAcceleration.reasonCode === "macOsCpuOnly" ? store.colmapAcceleration.reason : `${store.colmapAcceleration.reason} · 最低要求：驱动 ${store.colmapAcceleration.requirements.minimumDriverVersion}，Compute Capability ${store.colmapAcceleration.requirements.minimumComputeCapability}`}</small>
           </span>
         </div>
 
@@ -428,6 +433,7 @@ export function App() {
           <span><small>时长</small><b>{formatVideoDuration(store.video.duration)}</b></span>
           <span><small>分辨率</small><b>{store.video.width} × {store.video.height}</b></span>
           <span><small>预计帧数</small><b>约 {store.plan.estimatedFrames.toLocaleString()}</b></span>
+          <span title={store.estimate?.basis}><small>预计生成</small><b>{store.estimate ? `约 ${formatDuration(store.estimate.estimatedMs)}` : "分析中"}</b>{store.estimate && <em>{formatDuration(store.estimate.lowerBoundMs)}–{formatDuration(store.estimate.upperBoundMs)}</em>}</span>
         </div>}
 
         {store.video?.hasAlpha && <div className="alpha-source-status" role="status">
@@ -447,6 +453,7 @@ export function App() {
             <span><small>当前阶段</small><b>{currentStageLabel(store.latestEvent?.stage, activeStageIndex)}</b></span>
             <span><small>进度</small><b>{store.latestEvent?.current != null ? `${store.latestEvent.current.toLocaleString()}${store.latestEvent.total ? ` / ${store.latestEvent.total.toLocaleString()}` : ""}` : "持续运行"}</b></span>
             <span><small>总耗时</small><b>{formatDuration(liveElapsedMs)}</b></span>
+            <span><small>预计剩余</small><b>{projectedTiming ? formatDuration(projectedTiming.remainingMs) : "校准中"}</b></span>
           </div>
           <ol className="stage-timeline">
             {stages.map(([key, label], index) => <li key={key} className={index < activeStageIndex || store.phase === "completed" ? "done" : index === activeStageIndex && isRunning ? "active" : ""}><span /><b>{label}</b>{index === activeStageIndex && isRunning && <small>{store.latestEvent?.indeterminate ? "运行中" : `${(store.latestEvent?.stageProgress ?? 0).toFixed(0)}%`}</small>}</li>)}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,7 +10,7 @@ import {
   cancelPipeline, checkEngines, confirmAndDeleteProject, getProjectOverview,
   onPipelineEvent, probeAndPlan, revealProject, selectProjectsRoot, selectVideo,
   setProjectsRoot, startPipeline, prepareGaussianPreview, releaseGaussianPreview,
-  initializeTelemetry, setTelemetryConsent,
+  initializeTelemetry, setTelemetryConsent, resumePipeline,
 } from "../lib/backend";
 import { startElapsedTicker } from "../lib/elapsedTimer";
 import { useAppStore } from "../stores/appStore";
@@ -75,7 +75,7 @@ function engineReady(engine: EngineStatus) {
   return engine.canStart;
 }
 
-function ProjectRow({ project, busy, previewing, previewDisabled, onPreview, onDelete }: { project: ProjectSummary; busy: boolean; previewing: boolean; previewDisabled: boolean; onPreview: (project: ProjectSummary) => void; onDelete: (project: ProjectSummary) => void }) {
+function ProjectRow({ project, busy, previewing, previewDisabled, onPreview, onResume, onDelete }: { project: ProjectSummary; busy: boolean; previewing: boolean; previewDisabled: boolean; onPreview: (project: ProjectSummary) => void; onResume: (project: ProjectSummary) => void; onDelete: (project: ProjectSummary) => void }) {
   return <article className="project-row">
     <div className="project-row-main">
       <div className="project-title-line">
@@ -94,6 +94,7 @@ function ProjectRow({ project, busy, previewing, previewDisabled, onPreview, onD
     </dl>
     <div className="project-actions">
       {project.status === "completed" && <button className="preview-link" type="button" disabled={previewDisabled} onClick={() => onPreview(project)}>{previewing ? <LoaderCircle className="spin" size={14} /> : <Eye size={14} />}{previewing ? "正在打开" : "预览"}</button>}
+      {project.status !== "completed" && <button className="resume-link" type="button" disabled={busy} onClick={() => onResume(project)}><Play size={14} fill="currentColor" />继续任务</button>}
       <button type="button" onClick={() => void revealProject(project)}><MapPin size={14} />在文件管理器中显示</button>
       <button className="danger-link" type="button" disabled={busy} onClick={() => onDelete(project)}><Trash2 size={14} />删除</button>
     </div>
@@ -113,6 +114,7 @@ export function App() {
   const previewReleasePromises = useRef(new Map<string, Promise<void>>());
   const releasedPreviewProjects = useRef(new Set<string>());
   const runStartedAt = useRef<number | null>(null);
+  const runElapsedOffset = useRef(0);
   const [liveElapsedMs, setLiveElapsedMs] = useState(0);
   const [leftPanePercent, setLeftPanePercent] = useState(() => Math.min(68, Math.max(32, readSavedNumber("ooo-splat-left-pane", 44))));
   const [uiScale, setUiScale] = useState(() => Math.min(140, Math.max(80, readSavedNumber("ooo-splat-ui-scale", 100))));
@@ -158,7 +160,7 @@ export function App() {
     void onPipelineEvent((event) => {
       store.receiveEvent(event);
       if (["completed", "failed", "cancelled"].includes(event.stage)) {
-        setLiveElapsedMs(event.elapsedMs);
+        setLiveElapsedMs(runElapsedOffset.current + event.elapsedMs);
       }
     }).then((fn) => { unlisten = fn; });
     return () => unlisten?.();
@@ -168,7 +170,9 @@ export function App() {
 
   useEffect(() => {
     if (!isRunning || runStartedAt.current == null) return;
-    return startElapsedTicker(runStartedAt.current, setLiveElapsedMs);
+    return startElapsedTicker(runStartedAt.current, (elapsed) => {
+      setLiveElapsedMs(runElapsedOffset.current + elapsed);
+    });
   }, [isRunning]);
 
   useEffect(() => {
@@ -250,6 +254,7 @@ export function App() {
 
   const generate = async () => {
     if (!store.videoPath || !store.plan || !store.projectsRoot) return;
+    runElapsedOffset.current = 0;
     runStartedAt.current = Date.now();
     setLiveElapsedMs(0);
     store.beginRun();
@@ -268,6 +273,27 @@ export function App() {
       store.setPhase(message.includes("取消") ? "cancelled" : "failed");
     } finally {
       try { await refreshProjects(); } catch { /* the generated project remains on disk */ }
+    }
+  };
+
+  const resume = async (project: ProjectSummary) => {
+    runElapsedOffset.current = project.durationMs ?? 0;
+    runStartedAt.current = Date.now();
+    setLiveElapsedMs(runElapsedOffset.current);
+    store.beginRun();
+    try {
+      const result = await resumePipeline(project.id);
+      setLiveElapsedMs((current) => Math.max(current, result.durationMs));
+      store.setResult(result);
+      store.setPhase("completed");
+    } catch (error) {
+      const backendElapsed = useAppStore.getState().latestEvent?.elapsedMs ?? 0;
+      setLiveElapsedMs(runElapsedOffset.current + backendElapsed);
+      const message = messageOf(error);
+      store.setError(message);
+      store.setPhase(message.includes("取消") ? "cancelled" : "failed");
+    } finally {
+      try { await refreshProjects(); } catch { /* the project remains on disk */ }
     }
   };
 
@@ -469,8 +495,8 @@ export function App() {
 
         {completed.length === 0 && unfinished.length === 0 && <div className="empty-state"><FileBox size={30} strokeWidth={1.4} /><strong>还没有生成项目</strong><p>选择视频和项目目录后开始生成，成果会自动出现在这里。</p></div>}
 
-        {completed.length > 0 && <div className="project-group"><div className="group-heading"><span>已完成</span><small>{completed.length} 个项目</small></div>{completed.map((project) => <ProjectRow key={project.id} project={project} busy={isRunning} previewing={openingPreviewProjectId === project.id} previewDisabled={openingPreviewProjectId !== null || closingPreviewProjectId !== null} onPreview={(item) => void previewProject(item)} onDelete={(item) => void removeProject(item)} />)}</div>}
-        {unfinished.length > 0 && <div className="project-group unfinished"><div className="group-heading"><span>未完成</span><small>{unfinished.length} 个项目</small></div>{unfinished.map((project) => <ProjectRow key={project.id} project={project} busy={isRunning} previewing={false} previewDisabled onPreview={() => undefined} onDelete={(item) => void removeProject(item)} />)}</div>}
+        {completed.length > 0 && <div className="project-group"><div className="group-heading"><span>已完成</span><small>{completed.length} 个项目</small></div>{completed.map((project) => <ProjectRow key={project.id} project={project} busy={isRunning} previewing={openingPreviewProjectId === project.id} previewDisabled={openingPreviewProjectId !== null || closingPreviewProjectId !== null} onPreview={(item) => void previewProject(item)} onResume={() => undefined} onDelete={(item) => void removeProject(item)} />)}</div>}
+        {unfinished.length > 0 && <div className="project-group unfinished"><div className="group-heading"><span>未完成</span><small>{unfinished.length} 个项目</small></div>{unfinished.map((project) => <ProjectRow key={project.id} project={project} busy={isRunning} previewing={false} previewDisabled onPreview={() => undefined} onResume={(item) => void resume(item)} onDelete={(item) => void removeProject(item)} />)}</div>}
       </section>
     </section>
     </div>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,19 +7,19 @@ import {
 import appLogo from "../../assets/app-icon.svg";
 import { TelemetryPreferences } from "../components/TelemetryPreferences";
 import {
-  cancelPipeline, checkEngines, confirmAndDeleteProject, getProjectOverview,
+  cancelPipeline, checkEngines, confirmAndDeleteProject, estimateProjectRuntime, getProjectOverview,
   onPipelineEvent, probeAndPlan, revealProject, selectProjectsRoot, selectVideo,
   setProjectsRoot, startPipeline, prepareGaussianPreview, releaseGaussianPreview,
   initializeTelemetry, setTelemetryConsent, resumePipeline,
 } from "../lib/backend";
 import { startElapsedTicker } from "../lib/elapsedTimer";
-import { projectRuntime } from "../lib/runtimeEstimate";
 import { useAppStore } from "../stores/appStore";
 import { useGaussianTransformStore } from "../stores/gaussianTransformStore";
 import type { EngineStatus, ProjectStatus, ProjectSummary, Quality } from "../types/pipeline";
 import type { TelemetryPreferences as TelemetryPreferencesState } from "../types/telemetry";
 
 const GaussianViewer = lazy(() => import("../components/GaussianViewer").then((module) => ({ default: module.GaussianViewer })));
+const CANCELLATION_OVERLAY_DELAY_MS = 300;
 
 const qualities: Array<{ value: Quality; label: string; description: string }> = [
   { value: "fast", label: "快速", description: "快速验证素材与拍摄路径" },
@@ -116,7 +116,10 @@ export function App() {
   const releasedPreviewProjects = useRef(new Set<string>());
   const runStartedAt = useRef<number | null>(null);
   const runElapsedOffset = useRef(0);
+  const cancellationOverlayTimer = useRef<number | null>(null);
   const [liveElapsedMs, setLiveElapsedMs] = useState(0);
+  const [isCancellationRequested, setIsCancellationRequested] = useState(false);
+  const [showCancellationOverlay, setShowCancellationOverlay] = useState(false);
   const [leftPanePercent, setLeftPanePercent] = useState(() => Math.min(68, Math.max(32, readSavedNumber("ooo-splat-left-pane", 44))));
   const [uiScale, setUiScale] = useState(() => Math.min(140, Math.max(80, readSavedNumber("ooo-splat-ui-scale", 100))));
   const [isResizing, setIsResizing] = useState(false);
@@ -132,10 +135,20 @@ export function App() {
   const completed = useMemo(() => store.projects.filter((project) => project.status === "completed"), [store.projects]);
   const unfinished = useMemo(() => store.projects.filter((project) => project.status !== "completed"), [store.projects]);
   const activeStageIndex = stagePosition(store.latestEvent?.stage);
-  const projectedTiming = useMemo(
-    () => projectRuntime(store.estimate, store.progress, liveElapsedMs, isRunning),
-    [isRunning, liveElapsedMs, store.estimate, store.progress],
-  );
+  const liveProgressLabel = store.latestEvent?.unit === "estimated_progress" && store.latestEvent.stageProgress != null
+    ? `估算 ${store.latestEvent.stageProgress.toFixed(0)}%`
+    : store.latestEvent?.current != null
+      ? `${store.latestEvent.current.toLocaleString()}${store.latestEvent.total ? ` / ${store.latestEvent.total.toLocaleString()}` : ""}`
+      : "持续运行";
+
+  const clearCancellationFeedback = useCallback(() => {
+    if (cancellationOverlayTimer.current != null) {
+      window.clearTimeout(cancellationOverlayTimer.current);
+      cancellationOverlayTimer.current = null;
+    }
+    setIsCancellationRequested(false);
+    setShowCancellationOverlay(false);
+  }, []);
 
   const refreshProjects = async () => {
     const overview = await getProjectOverview();
@@ -179,6 +192,14 @@ export function App() {
       setLiveElapsedMs(runElapsedOffset.current + elapsed);
     });
   }, [isRunning]);
+
+  useEffect(() => {
+    if (!isRunning) clearCancellationFeedback();
+  }, [clearCancellationFeedback, isRunning]);
+
+  useEffect(() => () => {
+    if (cancellationOverlayTimer.current != null) window.clearTimeout(cancellationOverlayTimer.current);
+  }, []);
 
   useEffect(() => {
     try { window.localStorage.setItem("ooo-splat-left-pane", leftPanePercent.toFixed(1)); } catch { /* optional preference */ }
@@ -257,8 +278,24 @@ export function App() {
     if (store.videoPath) await analyze(store.videoPath, quality);
   };
 
+  const requestCancellation = async () => {
+    if (!isRunning || isCancellationRequested) return;
+    setIsCancellationRequested(true);
+    cancellationOverlayTimer.current = window.setTimeout(() => {
+      cancellationOverlayTimer.current = null;
+      setShowCancellationOverlay(true);
+    }, CANCELLATION_OVERLAY_DELAY_MS);
+    try {
+      await cancelPipeline();
+    } catch (error) {
+      clearCancellationFeedback();
+      store.setError(`无法终止任务：${messageOf(error)}`);
+    }
+  };
+
   const generate = async () => {
     if (!store.videoPath || !store.plan || !store.projectsRoot) return;
+    clearCancellationFeedback();
     runElapsedOffset.current = 0;
     runStartedAt.current = Date.now();
     setLiveElapsedMs(0);
@@ -282,9 +319,15 @@ export function App() {
   };
 
   const resume = async (project: ProjectSummary) => {
+    clearCancellationFeedback();
     runElapsedOffset.current = project.durationMs ?? 0;
     runStartedAt.current = Date.now();
     setLiveElapsedMs(runElapsedOffset.current);
+    try {
+      store.setEstimate(await estimateProjectRuntime(project.id));
+    } catch {
+      store.setEstimate(null);
+    }
     store.beginRun();
     try {
       const result = await resumePipeline(project.id);
@@ -430,10 +473,10 @@ export function App() {
         </div>
 
         {store.video && store.plan && <div className="source-metrics">
-          <span><small>时长</small><b>{formatVideoDuration(store.video.duration)}</b></span>
+          <span><small>素材时长</small><b>{formatVideoDuration(store.video.duration)}</b></span>
           <span><small>分辨率</small><b>{store.video.width} × {store.video.height}</b></span>
           <span><small>预计帧数</small><b>约 {store.plan.estimatedFrames.toLocaleString()}</b></span>
-          <span title={store.estimate?.basis}><small>预计生成</small><b>{store.estimate ? `约 ${formatDuration(store.estimate.estimatedMs)}` : "分析中"}</b>{store.estimate && <em>{formatDuration(store.estimate.lowerBoundMs)}–{formatDuration(store.estimate.upperBoundMs)}</em>}</span>
+          <span title={store.estimate?.basis}><small>预计时长</small><b>{store.estimate ? `约 ${formatDuration(store.estimate.estimatedMs)}` : "分析中"}</b>{store.estimate && <em>{formatDuration(store.estimate.lowerBoundMs)}–{formatDuration(store.estimate.upperBoundMs)}</em>}</span>
         </div>}
 
         {store.video?.hasAlpha && <div className="alpha-source-status" role="status">
@@ -451,9 +494,8 @@ export function App() {
           <p className="current-message">{store.progressMessage || "正在准备任务"}</p>
           <div className="process-metrics">
             <span><small>当前阶段</small><b>{currentStageLabel(store.latestEvent?.stage, activeStageIndex)}</b></span>
-            <span><small>进度</small><b>{store.latestEvent?.current != null ? `${store.latestEvent.current.toLocaleString()}${store.latestEvent.total ? ` / ${store.latestEvent.total.toLocaleString()}` : ""}` : "持续运行"}</b></span>
+            <span><small>进度</small><b>{liveProgressLabel}</b></span>
             <span><small>总耗时</small><b>{formatDuration(liveElapsedMs)}</b></span>
-            <span><small>预计剩余</small><b>{projectedTiming ? formatDuration(projectedTiming.remainingMs) : "校准中"}</b></span>
           </div>
           <ol className="stage-timeline">
             {stages.map(([key, label], index) => <li key={key} className={index < activeStageIndex || store.phase === "completed" ? "done" : index === activeStageIndex && isRunning ? "active" : ""}><span /><b>{label}</b>{index === activeStageIndex && isRunning && <small>{store.latestEvent?.indeterminate ? "运行中" : `${(store.latestEvent?.stageProgress ?? 0).toFixed(0)}%`}</small>}</li>)}
@@ -463,7 +505,7 @@ export function App() {
             {store.events.map((event, index) => <div className={`log-line ${event.level}`} key={`${event.sequence}-${index}`}><time>{new Date(event.timestamp).toLocaleTimeString("zh-CN", { hour12: false })}</time><span>{event.engine ?? "system"}</span><p>{event.message}</p></div>)}
             <div ref={logEnd} />
           </div>
-          {isRunning && <button className="cancel-action" type="button" onClick={() => void cancelPipeline()}><Square size={12} fill="currentColor" />取消任务并终止所有进程</button>}
+          {isRunning && <button className="cancel-action" type="button" disabled={isCancellationRequested} onClick={() => void requestCancellation()}>{isCancellationRequested ? <LoaderCircle className="spin" size={13} /> : <Square size={12} fill="currentColor" />}{isCancellationRequested ? "正在终止任务" : "取消任务并终止所有进程"}</button>}
         </section>}
 
         {store.error && <div className="inline-error"><CircleAlert size={16} /><span>{store.error}</span><button type="button" onClick={() => store.setError(null)}>关闭</button></div>}
@@ -516,6 +558,15 @@ export function App() {
       </div>}
       <button className="zoom-trigger" type="button" aria-expanded={showZoomControls} onClick={() => setShowZoomControls((visible) => !visible)}>{uiScale}%</button>
     </aside>
+    {showCancellationOverlay && isRunning && <div className="cancellation-backdrop" role="dialog" aria-modal="true" aria-labelledby="cancellation-title" aria-describedby="cancellation-description">
+      <div className="cancellation-status" aria-live="assertive" aria-busy="true">
+        <span className="cancellation-spinner" aria-hidden="true"><LoaderCircle className="spin" size={26} /></span>
+        <div>
+          <strong id="cancellation-title">正在终止任务</strong>
+          <p id="cancellation-description">正在关闭当前阶段及其子进程，请稍候。完成后此窗口会自动关闭。</p>
+        </div>
+      </div>
+    </div>}
     {telemetryPreferences && !telemetryPreferences.consentDecided && <TelemetryPreferences mode="consent" preferences={telemetryPreferences} busy={telemetryBusy} onChange={(enabled) => void changeTelemetryConsent(enabled)} />}
     {telemetryPreferences && privacySettingsOpen && <TelemetryPreferences mode="settings" preferences={telemetryPreferences} busy={telemetryBusy} onChange={(enabled) => void changeTelemetryConsent(enabled)} onClose={() => setPrivacySettingsOpen(false)} />}
   </main>;

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -2,7 +2,7 @@ import { convertFileSrc, invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { confirm, open, save } from "@tauri-apps/plugin-dialog";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
-import type { ColmapAccelerationStatus, EngineStatus, FramePlan, GaussianExportProgress, GaussianExportResult, GaussianPreviewDescriptor, GaussianTransform, GaussianVideoExportResult, GaussianVideoExportSession, PipelineEvent, PipelineResult, ProjectOverview, ProjectSummary, Quality, VideoInfo } from "../types/pipeline";
+import type { ColmapAccelerationStatus, EngineStatus, FramePlan, GaussianExportProgress, GaussianExportResult, GaussianPreviewDescriptor, GaussianTransform, GaussianVideoExportResult, GaussianVideoExportSession, PipelineEvent, PipelineResult, ProjectOverview, ProjectSummary, Quality, RuntimeEstimate, VideoInfo } from "../types/pipeline";
 import type { TelemetryPreferences } from "../types/telemetry";
 import { previewAssetUrl } from "./previewAssetUrl";
 
@@ -22,7 +22,7 @@ export async function selectProjectsRoot(current: string): Promise<string | null
 
 export async function checkEngines(): Promise<EngineStatus[]> { return inTauri() ? invoke("check_engines") : []; }
 export async function checkColmapAcceleration(): Promise<ColmapAccelerationStatus> { return invoke("check_colmap_acceleration"); }
-export async function probeAndPlan(path: string, quality: Quality): Promise<{ video: VideoInfo; plan: FramePlan }> { return invoke("probe_and_plan", { path, quality }); }
+export async function probeAndPlan(path: string, quality: Quality): Promise<{ video: VideoInfo; plan: FramePlan; estimate: RuntimeEstimate }> { return invoke("probe_and_plan", { path, quality }); }
 export async function getProjectOverview(): Promise<ProjectOverview> { return invoke("get_project_overview"); }
 export async function setProjectsRoot(projectsRoot: string): Promise<{ projectsRoot: string }> { return invoke("set_projects_root", { projectsRoot }); }
 export async function startPipeline(path: string, quality: Quality, projectsRoot: string): Promise<PipelineResult> { return invoke("start_pipeline", { path, quality, projectsRoot }); }

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -26,6 +26,7 @@ export async function probeAndPlan(path: string, quality: Quality): Promise<{ vi
 export async function getProjectOverview(): Promise<ProjectOverview> { return invoke("get_project_overview"); }
 export async function setProjectsRoot(projectsRoot: string): Promise<{ projectsRoot: string }> { return invoke("set_projects_root", { projectsRoot }); }
 export async function startPipeline(path: string, quality: Quality, projectsRoot: string): Promise<PipelineResult> { return invoke("start_pipeline", { path, quality, projectsRoot }); }
+export async function resumePipeline(projectId: string): Promise<PipelineResult> { return invoke("resume_pipeline", { projectId }); }
 export async function cancelPipeline(): Promise<void> { return invoke("cancel_pipeline"); }
 export async function onPipelineEvent(handler: (event: PipelineEvent) => void): Promise<UnlistenFn> { return listen<PipelineEvent>("pipeline-event", ({ payload }) => handler(payload)); }
 export async function initializeTelemetry(): Promise<TelemetryPreferences> { return invoke("initialize_telemetry"); }

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -23,6 +23,7 @@ export async function selectProjectsRoot(current: string): Promise<string | null
 export async function checkEngines(): Promise<EngineStatus[]> { return inTauri() ? invoke("check_engines") : []; }
 export async function checkColmapAcceleration(): Promise<ColmapAccelerationStatus> { return invoke("check_colmap_acceleration"); }
 export async function probeAndPlan(path: string, quality: Quality): Promise<{ video: VideoInfo; plan: FramePlan; estimate: RuntimeEstimate }> { return invoke("probe_and_plan", { path, quality }); }
+export async function estimateProjectRuntime(projectId: string): Promise<RuntimeEstimate> { return invoke("estimate_project_runtime", { projectId }); }
 export async function getProjectOverview(): Promise<ProjectOverview> { return invoke("get_project_overview"); }
 export async function setProjectsRoot(projectsRoot: string): Promise<{ projectsRoot: string }> { return invoke("set_projects_root", { projectsRoot }); }
 export async function startPipeline(path: string, quality: Quality, projectsRoot: string): Promise<PipelineResult> { return invoke("start_pipeline", { path, quality, projectsRoot }); }

--- a/src/lib/runtimeEstimate.test.ts
+++ b/src/lib/runtimeEstimate.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import type { RuntimeEstimate } from "../types/pipeline";
+import { projectRuntime } from "./runtimeEstimate";
+
+const estimate: RuntimeEstimate = {
+  estimatedMs: 100_000,
+  lowerBoundMs: 60_000,
+  upperBoundMs: 160_000,
+  confidence: "low",
+  sampleCount: 0,
+  basis: "test",
+};
+
+describe("runtime projection", () => {
+  it("uses the initial estimate before enough live progress is available", () => {
+    expect(projectRuntime(estimate, 4, 20_000, true)).toEqual({
+      projectedTotalMs: 100_000,
+      remainingMs: 80_000,
+    });
+  });
+
+  it("blends observed progress without exceeding the safety bounds", () => {
+    const projected = projectRuntime(estimate, 10, 20_000, true);
+    expect(projected?.projectedTotalMs).toBe(145_000);
+    expect(projected?.remainingMs).toBe(125_000);
+
+    expect(projectRuntime(estimate, 5, 1_000_000, true)?.projectedTotalMs).toBe(200_000);
+  });
+
+  it("returns null when no estimate exists", () => {
+    expect(projectRuntime(null, 50, 30_000, true)).toBeNull();
+  });
+});

--- a/src/lib/runtimeEstimate.ts
+++ b/src/lib/runtimeEstimate.ts
@@ -1,0 +1,33 @@
+import type { RuntimeEstimate } from "../types/pipeline";
+
+export interface ProjectedRuntime {
+  projectedTotalMs: number;
+  remainingMs: number;
+}
+
+export function projectRuntime(
+  estimate: RuntimeEstimate | null,
+  progressPercent: number,
+  elapsedMs: number,
+  running: boolean,
+): ProjectedRuntime | null {
+  if (!estimate) return null;
+
+  let projectedTotalMs = estimate.estimatedMs;
+  const progressFraction = Math.min(1, Math.max(0, progressPercent / 100));
+  if (running && elapsedMs >= 10_000 && progressFraction >= 0.05) {
+    const observedTotal = elapsedMs / progressFraction;
+    projectedTotalMs = Math.min(
+      estimate.upperBoundMs * 1.25,
+      Math.max(
+        estimate.lowerBoundMs * 0.8,
+        estimate.estimatedMs * 0.55 + observedTotal * 0.45,
+      ),
+    );
+  }
+
+  return {
+    projectedTotalMs,
+    remainingMs: Math.max(0, projectedTotalMs - elapsedMs),
+  };
+}

--- a/src/stores/appStore.test.ts
+++ b/src/stores/appStore.test.ts
@@ -24,7 +24,7 @@ describe("app store", () => {
   beforeEach(() => {
     useAppStore.setState({
       videoPath: null, projectsRoot: "", projects: [], quality: "balanced", colmapAcceleration: null, video: null,
-      plan: null, engines: [], phase: "idle", progress: 0, progressMessage: "",
+      plan: null, estimate: null, engines: [], phase: "idle", progress: 0, progressMessage: "",
       latestEvent: null, events: [], result: null, error: null,
     });
   });
@@ -34,10 +34,14 @@ describe("app store", () => {
   });
 
   it("invalidates a plan when quality changes", () => {
-    useAppStore.setState({ plan: { retentionRatio: 0.5, samplingFps: 15, estimatedFrames: 900 } });
+    useAppStore.setState({
+      plan: { retentionRatio: 0.5, samplingFps: 15, estimatedFrames: 900 },
+      estimate: { estimatedMs: 100_000, lowerBoundMs: 60_000, upperBoundMs: 160_000, confidence: "low", sampleCount: 1, basis: "test" },
+    });
     useAppStore.getState().setQuality("high");
     expect(useAppStore.getState().quality).toBe("high");
     expect(useAppStore.getState().plan).toBeNull();
+    expect(useAppStore.getState().estimate).toBeNull();
   });
 
   it("keeps progress monotonic and ignores stale sequenced events", () => {

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import type { ColmapAccelerationStatus, EngineStatus, FramePlan, PipelineEvent, PipelineResult, ProjectSummary, Quality, RunPhase, VideoInfo } from "../types/pipeline";
+import type { ColmapAccelerationStatus, EngineStatus, FramePlan, PipelineEvent, PipelineResult, ProjectSummary, Quality, RunPhase, RuntimeEstimate, VideoInfo } from "../types/pipeline";
 
 interface AppState {
   videoPath: string | null;
@@ -9,6 +9,7 @@ interface AppState {
   colmapAcceleration: ColmapAccelerationStatus | null;
   video: VideoInfo | null;
   plan: FramePlan | null;
+  estimate: RuntimeEstimate | null;
   engines: EngineStatus[];
   phase: RunPhase;
   progress: number;
@@ -22,7 +23,7 @@ interface AppState {
   setProjects: (projects: ProjectSummary[]) => void;
   setQuality: (quality: Quality) => void;
   setColmapAcceleration: (acceleration: ColmapAccelerationStatus | null) => void;
-  setAnalysis: (video: VideoInfo, plan: FramePlan) => void;
+  setAnalysis: (video: VideoInfo, plan: FramePlan, estimate: RuntimeEstimate) => void;
   setEngines: (engines: EngineStatus[]) => void;
   setPhase: (phase: RunPhase) => void;
   beginRun: () => void;
@@ -39,6 +40,7 @@ export const useAppStore = create<AppState>((set) => ({
   colmapAcceleration: null,
   video: null,
   plan: null,
+  estimate: null,
   engines: [],
   phase: "idle",
   progress: 0,
@@ -47,12 +49,12 @@ export const useAppStore = create<AppState>((set) => ({
   events: [],
   result: null,
   error: null,
-  setVideoPath: (videoPath) => set({ videoPath, video: null, plan: null, result: null, error: null, progress: 0, phase: "idle" }),
+  setVideoPath: (videoPath) => set({ videoPath, video: null, plan: null, estimate: null, result: null, error: null, progress: 0, phase: "idle" }),
   setProjectsRoot: (projectsRoot) => set({ projectsRoot }),
   setProjects: (projects) => set({ projects }),
-  setQuality: (quality) => set({ quality, plan: null, result: null, error: null }),
+  setQuality: (quality) => set({ quality, plan: null, estimate: null, result: null, error: null }),
   setColmapAcceleration: (colmapAcceleration) => set({ colmapAcceleration }),
-  setAnalysis: (video, plan) => set({ video, plan }),
+  setAnalysis: (video, plan, estimate) => set({ video, plan, estimate }),
   setEngines: (engines) => set({ engines }),
   setPhase: (phase) => set({ phase }),
   beginRun: () => set({ phase: "running", progress: 0, progressMessage: "正在创建项目", latestEvent: null, events: [], result: null, error: null }),

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -24,6 +24,7 @@ interface AppState {
   setQuality: (quality: Quality) => void;
   setColmapAcceleration: (acceleration: ColmapAccelerationStatus | null) => void;
   setAnalysis: (video: VideoInfo, plan: FramePlan, estimate: RuntimeEstimate) => void;
+  setEstimate: (estimate: RuntimeEstimate | null) => void;
   setEngines: (engines: EngineStatus[]) => void;
   setPhase: (phase: RunPhase) => void;
   beginRun: () => void;
@@ -55,6 +56,7 @@ export const useAppStore = create<AppState>((set) => ({
   setQuality: (quality) => set({ quality, plan: null, estimate: null, result: null, error: null }),
   setColmapAcceleration: (colmapAcceleration) => set({ colmapAcceleration }),
   setAnalysis: (video, plan, estimate) => set({ video, plan, estimate }),
+  setEstimate: (estimate) => set({ estimate }),
   setEngines: (engines) => set({ engines }),
   setPhase: (phase) => set({ phase }),
   beginRun: () => set({ phase: "running", progress: 0, progressMessage: "正在创建项目", latestEvent: null, events: [], result: null, error: null }),

--- a/src/styles.css
+++ b/src/styles.css
@@ -195,6 +195,7 @@ h1, h2 { margin: 0; font: 650 29px/1 "Bahnschrift", "Microsoft YaHei UI", sans-s
 .project-actions button { padding: 4px 0; display: flex; align-items: center; gap: 5px; color: #536078; background: transparent; border: 0; cursor: pointer; font-size: 10px; }
 .project-actions button:hover:not(:disabled) { color: var(--blue); }
 .project-actions .preview-link { color: var(--blue); font-weight: 700; }
+.project-actions .resume-link { color: var(--blue); font-weight: 700; }
 .project-actions .danger-link:hover:not(:disabled) { color: var(--red); }
 
 .preview-mode { background: #e7ebf1; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -112,7 +112,7 @@ h1, h2 { margin: 0; font: 650 29px/1 "Bahnschrift", "Microsoft YaHei UI", sans-s
 .acceleration-status.warning .acceleration-icon, .acceleration-status.warning strong { color: var(--amber); }
 .acceleration-status + .source-metrics { margin-top: 20px; }
 
-.source-metrics { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.source-metrics { display: grid; grid-template-columns: repeat(4, 1fr); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
 .source-metrics span { min-width: 0; padding: 13px 8px; display: grid; gap: 5px; border-right: 1px solid var(--line); }
 .source-metrics span:first-child { padding-left: 0; }
 .source-metrics span:last-child { border-right: 0; }
@@ -122,6 +122,7 @@ h1, h2 { margin: 0; font: 650 29px/1 "Bahnschrift", "Microsoft YaHei UI", sans-s
 .alpha-source-status > span { min-width: 0; display: grid; gap: 4px; }
 .alpha-source-status strong { font-size: 12px; }
 .alpha-source-status small { color: var(--muted); font-size: 11px; line-height: 1.45; overflow-wrap: anywhere; }
+.source-metrics em { color: var(--faint); font: 400 9px/1.2 "Cascadia Mono", monospace; white-space: nowrap; }
 .primary-action { width: 100%; height: 48px; margin-top: 20px; padding: 0 15px; display: flex; align-items: center; justify-content: center; gap: 9px; color: white; background: var(--blue); border: 0; cursor: pointer; font-size: 13px; font-weight: 700; transition: background 150ms; }
 .primary-action:hover:not(:disabled) { background: var(--blue-dark); }
 
@@ -131,7 +132,7 @@ h1, h2 { margin: 0; font: 650 29px/1 "Bahnschrift", "Microsoft YaHei UI", sans-s
 .live-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--blue); animation: pulse 1.6s ease-in-out infinite; }
 .mono { font: 650 13px/1 "Cascadia Mono", monospace; }
 .current-message { min-height: 20px; margin: 14px 0 0; color: #455064; font-size: 12px; line-height: 1.55; }
-.process-metrics { margin-top: 13px; display: grid; grid-template-columns: .8fr 1.2fr .8fr; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.process-metrics { margin-top: 13px; display: grid; grid-template-columns: .8fr 1.2fr .8fr .9fr; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
 .process-metrics span { min-width: 0; padding: 11px 10px; display: grid; gap: 5px; border-right: 1px solid var(--line); }
 .process-metrics span:first-child { padding-left: 0; }
 .process-metrics span:last-child { border: 0; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -132,7 +132,7 @@ h1, h2 { margin: 0; font: 650 29px/1 "Bahnschrift", "Microsoft YaHei UI", sans-s
 .live-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--blue); animation: pulse 1.6s ease-in-out infinite; }
 .mono { font: 650 13px/1 "Cascadia Mono", monospace; }
 .current-message { min-height: 20px; margin: 14px 0 0; color: #455064; font-size: 12px; line-height: 1.55; }
-.process-metrics { margin-top: 13px; display: grid; grid-template-columns: .8fr 1.2fr .8fr .9fr; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.process-metrics { margin-top: 13px; display: grid; grid-template-columns: .8fr 1.2fr .8fr; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
 .process-metrics span { min-width: 0; padding: 11px 10px; display: grid; gap: 5px; border-right: 1px solid var(--line); }
 .process-metrics span:first-child { padding-left: 0; }
 .process-metrics span:last-child { border: 0; }
@@ -157,6 +157,41 @@ h1, h2 { margin: 0; font: 650 29px/1 "Bahnschrift", "Microsoft YaHei UI", sans-s
 .log-line.warning p { color: #ffd68e; }
 .log-line.error p { color: #ffaaa1; }
 .cancel-action { margin-top: 12px; padding: 8px 0; display: flex; align-items: center; gap: 7px; color: var(--red); background: transparent; border: 0; cursor: pointer; font-size: 11px; }
+.cancellation-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(19, 26, 39, .54);
+  backdrop-filter: blur(3px);
+}
+.cancellation-status {
+  width: min(420px, calc(100vw - 48px));
+  min-height: 112px;
+  padding: 24px 26px;
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  gap: 17px;
+  align-items: center;
+  color: var(--ink);
+  background: rgba(248, 249, 251, .96);
+  border: 1px solid var(--line-dark);
+  box-shadow: 0 20px 54px rgba(10, 17, 29, .24);
+}
+.cancellation-spinner {
+  width: 46px;
+  height: 46px;
+  display: grid;
+  place-items: center;
+  color: var(--blue);
+  background: #edf2ff;
+  border: 1px solid #c8d6ff;
+  border-radius: 50%;
+}
+.cancellation-status strong { display: block; margin-bottom: 7px; font-size: 15px; }
+.cancellation-status p { margin: 0; color: var(--muted); font-size: 12px; line-height: 1.65; }
 .inline-error { margin-top: 16px; padding: 10px 0; display: grid; grid-template-columns: 18px 1fr auto; gap: 8px; align-items: start; color: var(--red); border-top: 1px solid #e4c1bd; border-bottom: 1px solid #e4c1bd; font-size: 12px; line-height: 1.5; }
 .inline-error button { color: inherit; background: transparent; border: 0; cursor: pointer; font-size: 11px; }
 

--- a/src/types/pipeline.ts
+++ b/src/types/pipeline.ts
@@ -9,7 +9,7 @@ export type AccelerationReasonCode =
   | "nvidiaSmiNotFound" | "probeFailed" | "probeTimeout" | "noNvidiaGpu"
   | "driverVersionUnknown" | "driverTooOld" | "computeCapabilityUnknown"
   | "computeCapabilityTooLow";
-export interface GpuDeviceInfo { index: number; name: string; driverVersion: string; computeCapability: string; }
+export interface GpuDeviceInfo { index: number; name: string; driverVersion: string; computeCapability: string; totalMemoryMb?: number; }
 export interface AccelerationRequirements { minimumDriverVersion: string; minimumComputeCapability: string; }
 export interface ColmapAccelerationStatus {
   backend: ColmapBackend;
@@ -31,6 +31,14 @@ export interface VideoInfo {
   hasAlpha: boolean;
 }
 export interface FramePlan { retentionRatio: number; samplingFps: number; estimatedFrames: number; }
+export interface RuntimeEstimate {
+  estimatedMs: number;
+  lowerBoundMs: number;
+  upperBoundMs: number;
+  confidence: "low" | "medium" | "high";
+  sampleCount: number;
+  basis: string;
+}
 
 export interface PipelineEvent {
   sequence: number;


### PR DESCRIPTION
## Summary

- add durable stage-level checkpoints for interrupted, failed, and cancelled pipelines
- resume from the latest valid completed stage without repeating trustworthy work
- validate checkpoints before reuse and automatically roll back to the earliest invalid stage
- show a **Continue task** action for resumable projects and classify stale running projects as interrupted
- estimate total generation time from input frame count, quality preset, and completed local runs
- display NVIDIA GPU name, VRAM, driver, and Compute Capability without changing device-selection rules
- show a blocking cancellation indicator when terminating a process tree takes longer than expected
- improve the Brush stage with a clearly labelled, time-calibrated estimated progress indicator

## Scope intentionally retained

This revision keeps the existing reconstruction and quality behavior from `main`:

- existing frame-retention ratios and frame planning
- COLMAP sequential matcher
- existing incremental mapper
- existing Brush iterations, maximum resolution, and Splat parameters
- existing COLMAP GPU auto-detection and CPU fallback

It does **not** include the earlier low-VRAM parameter changes, OOM retry profiles, Global Mapper, exhaustive matching, guided matching, or reconstruction-strategy changes.

## Checkpoint behavior

- complete FFmpeg frames are reused after validating the recorded count
- transparent projects additionally validate PNG/Mask one-to-one correspondence
- feature and matching checkpoints require a valid non-empty COLMAP database
- sparse reconstruction is reused only after the existing reconstruction validator succeeds
- Brush output is reused only when the Gaussian PLY header, size, and Splat count are valid
- invalid artifacts cause the pipeline to clean the affected downstream work directories and restart from the earliest untrusted stage
- the stage that was interrupted is restarted from the beginning; subprocess-internal progress is not resumed

## Runtime estimate

- provides estimated, lower-bound, and upper-bound durations before generation
- calibrates from up to 20 completed local projects, preferring the same quality preset and similar frame counts
- falls back to a built-in frame-count and quality model for first-time users
- accumulates elapsed time across retries and resumed runs
- Brush v0.3.0 does not expose current steps through stdout/stderr, so its live percentage is explicitly labelled as estimated and remains below 100% until the process exits successfully

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml` — 90 passed
- `npm test -- --run` — 56 passed
- `npm run build`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- Windows NSIS installer built successfully
- no full FFmpeg/COLMAP/Brush generation run was performed for this revision
