### PR TITLE
feat(ui): show the reconstruction quality warning the backend already returns

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,7 +2,7 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type
 import {
   Blend, ChevronDown, ChevronRight, CircleAlert, Clapperboard, Cpu, FileBox, Images,
   Eye, FolderOpen, LoaderCircle, MapPin, Minus, Play, Plus, RotateCcw, Square, Trash2,
-  Settings2, Zap,
+  Settings2, TriangleAlert, Zap,
 } from "lucide-react";
 import appLogo from "../../assets/app-icon.svg";
 import packageMetadata from "../../package.json";
@@ -542,6 +542,8 @@ export function App() {
           </div>
           {isRunning && <button className="cancel-action" type="button" disabled={isCancellationRequested} onClick={() => void requestCancellation()}>{isCancellationRequested ? <LoaderCircle className="spin" size={13} /> : <Square size={12} fill="currentColor" />}{isCancellationRequested ? "正在终止任务" : "取消任务并终止所有进程"}</button>}
         </section>}
+
+        {store.result?.warning && <div className="inline-warning"><TriangleAlert size={16} /><span>{store.result.warning}</span></div>}
 
         {store.error && <div className="inline-error"><CircleAlert size={16} /><span>{store.error}</span><button type="button" onClick={() => store.setError(null)}>关闭</button></div>}
       </section>

--- a/src/app/App.warning.test.tsx
+++ b/src/app/App.warning.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppStore } from "../stores/appStore";
+import type { PipelineResult } from "../types/pipeline";
+
+const mocks = vi.hoisted(() => ({
+  initializeTelemetry: vi.fn(),
+  getProjectOverview: vi.fn(),
+}));
+
+vi.mock("../lib/backend", () => ({
+  cancelPipeline: vi.fn(),
+  checkEngines: vi.fn().mockResolvedValue([]),
+  confirmAndDeleteProject: vi.fn().mockResolvedValue(false),
+  confirmLargeImageSequence: vi.fn().mockResolvedValue(true),
+  estimateProjectRuntime: vi.fn(),
+  getProjectOverview: mocks.getProjectOverview,
+  initializeTelemetry: mocks.initializeTelemetry,
+  onPipelineEvent: vi.fn().mockResolvedValue(() => undefined),
+  prepareGaussianPreview: vi.fn(),
+  probeAndPlan: vi.fn(),
+  releaseGaussianPreview: vi.fn(),
+  resumePipeline: vi.fn(),
+  revealProject: vi.fn(),
+  selectImageSequence: vi.fn().mockResolvedValue(null),
+  selectProjectsRoot: vi.fn(),
+  selectVideo: vi.fn().mockResolvedValue(null),
+  setProjectsRoot: vi.fn(),
+  setTelemetryConsent: vi.fn(),
+  startPipeline: vi.fn(),
+}));
+
+vi.mock("../components/GaussianViewer", () => ({
+  GaussianViewer: () => <section className="preview-workspace" />,
+}));
+
+import { App } from "./App";
+
+const result = (warning: string | null): PipelineResult => ({
+  projectId: "11111111-1111-1111-1111-111111111111",
+  projectPath: "E:\\Projects\\示例项目",
+  finalPly: "E:\\Projects\\示例项目\\final.ply",
+  fileSize: 73_729_603,
+  splatCount: 312_407,
+  inputImages: 200,
+  registeredImages: 110,
+  registeredRatio: 0.55,
+  points3d: 10_000,
+  durationMs: 3_600_000,
+  completedAt: "2026-08-22T15:00:00Z",
+  warning,
+  logsDirectory: "E:\\Projects\\示例项目\\logs",
+});
+
+const flush = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+};
+
+describe("App reconstruction warning", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    // jsdom does not implement scrollIntoView, and starting a run renders the live log,
+    // whose auto-scroll effect then calls it.
+    Element.prototype.scrollIntoView = vi.fn();
+    useAppStore.setState({
+      inputPath: null, inputType: "video", projectsRoot: "E:\\Projects", projects: [], quality: "balanced", colmapAcceleration: null,
+      video: null, imageSequence: null, plan: null, estimate: null, engines: [], phase: "idle", progress: 0, progressMessage: "",
+      latestEvent: null, events: [], result: null, error: null,
+    });
+    mocks.getProjectOverview.mockReset().mockResolvedValue({ projectsRoot: "E:\\Projects", projects: [] });
+    mocks.initializeTelemetry.mockReset().mockResolvedValue({
+      analyticsEnabled: true, consentDecided: true, deliveryStatus: "configured",
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => { root.render(<App />); });
+    await flush();
+  });
+
+  afterEach(async () => {
+    await act(async () => { root.unmount(); });
+    container.remove();
+  });
+
+  it("shows the reconstruction quality warning the backend returns", async () => {
+    expect(container.querySelector(".inline-warning")).toBeNull();
+
+    const warning = "注册率 55.0%：低于 80%，将继续训练，但结果质量可能受影响";
+    await act(async () => {
+      useAppStore.setState({ phase: "completed" });
+      useAppStore.getState().setResult(result(warning));
+    });
+    await flush();
+
+    expect(container.querySelector(".inline-warning")?.textContent).toContain(warning);
+  });
+
+  it("stays hidden for a run the backend did not flag", async () => {
+    await act(async () => {
+      useAppStore.setState({ phase: "completed" });
+      useAppStore.getState().setResult(result(null));
+    });
+    await flush();
+
+    expect(container.querySelector(".inline-warning")).toBeNull();
+  });
+
+  it("clears the warning when the next run starts", async () => {
+    await act(async () => {
+      useAppStore.setState({ phase: "completed" });
+      useAppStore.getState().setResult(result("注册率 55.0%：低于 80%，将继续训练，但结果质量可能受影响"));
+    });
+    await flush();
+    expect(container.querySelector(".inline-warning")).not.toBeNull();
+
+    await act(async () => { useAppStore.getState().beginRun(); });
+    await flush();
+
+    expect(container.querySelector(".inline-warning")).toBeNull();
+  });
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -211,6 +211,7 @@ h1, h2 { margin: 0; font: 650 29px/1 "Bahnschrift", "Microsoft YaHei UI", sans-s
 .cancellation-status p { margin: 0; color: var(--muted); font-size: 12px; line-height: 1.65; }
 .inline-error { margin-top: 16px; padding: 10px 0; display: grid; grid-template-columns: 18px 1fr auto; gap: 8px; align-items: start; color: var(--red); border-top: 1px solid #e4c1bd; border-bottom: 1px solid #e4c1bd; font-size: 12px; line-height: 1.5; }
 .inline-error button { color: inherit; background: transparent; border: 0; cursor: pointer; font-size: 11px; }
+.inline-warning { margin-top: 16px; padding: 10px 0; display: grid; grid-template-columns: 18px 1fr; gap: 8px; align-items: start; color: var(--amber); border-top: 1px solid #e6d3a8; border-bottom: 1px solid #e6d3a8; font-size: 12px; line-height: 1.5; }
 
 .refresh-action { padding: 7px 0; display: flex; align-items: center; gap: 6px; color: var(--muted); background: transparent; border: 0; cursor: pointer; font-size: 11px; }
 .archive-summary { margin-bottom: 24px; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); border-top: 1px solid var(--line-dark); border-bottom: 1px solid var(--line-dark); }


### PR DESCRIPTION
## Summary

When COLMAP registers fewer than 80% of the extracted frames, `runner.rs` builds the warning:

> 注册率 {:.1}%：低于 80%，将继续训练，但结果质量可能受影响

and returns it as `PipelineResult.warning`.

`App.tsx` stores that result with `store.setResult(result)` but never reads it — `grep "store.result" src/app/App.tsx` matches nothing — so the field is write-only and the warning has never reached a user.

The cost falls on the runs that go wrong: an orbit video that registers only 55% of its frames produces a visibly poor splat, with no explanation and no hint that reshooting with more overlap is the fix, even though the app already computed the reason and carried it all the way to the frontend.

## Changes

- Render `PipelineResult.warning` as an amber banner beside the existing error banner.
- Reuse the error banner’s border treatment and the existing `--amber` token.
- The banner is deliberately not dismissible: `beginRun` already clears `result`, so it disappears when the next run starts and stays visible while the user inspects the result it describes.

## Out of scope

`ProjectSummary` also carries `registeredRatio`, `splatCount`, and `points3d` that `ProjectRow` never renders, so the history list still shows nothing about a weak reconstruction after a restart. That needs a layout decision and belongs in its own change.

## Test plan

- [x] Verified on Ubuntu 24.04 against `4bed6a9`
- [x] `npm test` — 78 passed
- [x] `tsc -b` — clean
- [x] The two positive assertions in the new test fail without the render change