### PR TITLE
docs: document the anonymous usage statistics in both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,30 @@ sudo apt install ./OOOSplat-0.4.0-x64-linux.deb
 ```text
 %LOCALAPPDATA%\SplatStudio\settings.json
 %LOCALAPPDATA%\SplatStudio\project-index.json
+%LOCALAPPDATA%\SplatStudio\telemetry.json
 ```
+
+## 匿名使用统计
+
+OOOSplat 默认开启匿名使用统计，用于了解稳定性和各阶段耗时。可在右上角 **设置 → 隐私** 中随时关闭，关闭后不再发送任何请求。
+
+会发送的内容：
+
+| 字段 | 说明 |
+| --- | --- |
+| 安装 ID | 首次启动生成的随机 UUID，不读取硬件序列号、MAC 地址或设备指纹 |
+| 应用版本、操作系统、CPU 架构 | 例如 `0.4.0` / `windows` / `x86_64` |
+| 事件名 | `daily_active`、`generation_started`、`generation_completed`、`generation_failed`、`pipeline_stage_completed`。`daily_active` 每天最多一次，应用升级后当天会再报一次 |
+| 质量档位与输入类型 | 枚举值，例如 `balanced` / `video`；图片序列输入报 `images` |
+| 阶段耗时与总耗时 | 毫秒 |
+| 帧数与视频时长 | 分桶值，不是原始数量 |
+| 失败阶段与错误码 | 枚举值，例如 `colmap_mapper_failed`；不含原始错误文本 |
+
+不会发送的内容：视频、图片、PLY 等任何素材；文件名、路径和项目名称；日志与命令输出；用户名或任何个人信息。
+
+数据发送到 `https://www.ooolab.cn/api/telemetry/event`。这是应用唯一的对外网络请求，抽帧、重建与训练全部在本机完成。
+
+开关状态和安装 ID 保存在 `%LOCALAPPDATA%\SplatStudio\telemetry.json`。删除该文件会在下次启动时生成一个新的随机安装 ID。
 
 ## 内置引擎
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -193,7 +193,30 @@ Application settings and the project index are stored in:
 ```text
 %LOCALAPPDATA%\SplatStudio\settings.json
 %LOCALAPPDATA%\SplatStudio\project-index.json
+%LOCALAPPDATA%\SplatStudio\telemetry.json
 ```
+
+## Anonymous Usage Statistics
+
+OOOSplat collects anonymous usage statistics by default to track stability and per-stage timings. Turn it off at any time under **Settings -> Privacy** in the top right; nothing is sent once it is off.
+
+What is sent:
+
+| Field | Description |
+| --- | --- |
+| Install ID | A random UUID generated on first launch. No hardware serial, MAC address, or device fingerprint is read |
+| App version, OS, CPU architecture | For example `0.4.0` / `windows` / `x86_64` |
+| Event name | `daily_active`, `generation_started`, `generation_completed`, `generation_failed`, `pipeline_stage_completed`. `daily_active` is sent at most once a day, and once more on the day the app version changes |
+| Quality preset and input type | Enumerated values such as `balanced` / `video`; an image-sequence input reports `images` |
+| Stage and total durations | Milliseconds |
+| Frame count and video duration | Bucketed values, not raw counts |
+| Failing stage and error code | Enumerated values such as `colmap_mapper_failed`; no raw error text |
+
+What is never sent: any source media, including videos, images, and PLY files; file names, paths, and project names; logs and command output; user names or any personal information.
+
+Statistics are sent to `https://www.ooolab.cn/api/telemetry/event`. This is the application's only outbound network request; frame extraction, reconstruction, and training all run locally.
+
+The preference and the install ID are stored in `%LOCALAPPDATA%\SplatStudio\telemetry.json`. Deleting that file generates a new random install ID on the next launch.
 
 ## Bundled Engines
 


### PR DESCRIPTION
## Summary

OOOSplat sends anonymous usage statistics to `https://www.ooolab.cn/api/telemetry/event`. The feature is on by default, and neither README currently mentions it.

The in-app privacy dialog already describes the data well. A user comparing tools, however, usually reads the README first. The README’s own feature list is where the gap is most noticeable: the “安全与隐私保护” / “Security and privacy protection” section carefully and accurately states that original videos, images, and models are never uploaded, but does not mention the one outbound request the application does make.

## Changes

Documentation only — no behavior change. The on-by-default setting is left as-is (a product decision for the maintainers).

Adds a short section to both READMEs covering:

- What is sent
- What is never sent
- The endpoint
- How to turn it off

Every detail is taken from the code (not the dialog copy):

- Payload fields in `telemetry/event.rs`: install ID, app version, OS, architecture, event name, quality preset, input type, durations, bucketed frame count and video duration, failing stage and error code
- The snake_case wire names those enums serialize to
- `daily_active` cadence: at most once a day, plus once more when the app version changes
- The `images` input type reported for an image-sequence project
- The top-right Settings toggle that gates delivery in `telemetry/service.rs`

Also records `telemetry.json` alongside `settings.json` and `project-index.json` in the file-locations block (where the preference and the random install ID live), and notes that deleting it generates a new ID.

The claim that this is the application’s only outbound request was checked rather than assumed: `telemetry/service.rs` holds the only HTTP client in the backend, and `tauri.conf.json` configures no updater.

## Test plan

- [x] Documentation-only change; no code paths modified
- [x] Cross-checked every listed field and behavior against the current source