### PR TITLE
功能：智能抽帧（质量与时序筛选替代固定比例均匀抽帧）

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -692,6 +692,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622f3fc73690be383c7214310406f28a90e6edeadc3cea882f9d71e495b9711a"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc74980687109a3b14c72fd458107bf0baa1da1a1a805e178d15501ba9b86d9d"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1013,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "embed-resource"
@@ -2582,6 +2607,7 @@ dependencies = [
  "dirs",
  "image",
  "libc",
+ "rayon",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -3037,6 +3063,26 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 dirs = "6"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
+rayon = "1.10"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/bin/splatstudio.rs
+++ b/src-tauri/src/bin/splatstudio.rs
@@ -8,8 +8,9 @@ use ooo_splat::{
     presets::Quality,
     process::ProcessManager,
     video::{
-        analyze_image_sequence, create_image_plan, prepare_image_sequence, FrameSelectionStrategy,
-        UniformRatioFrameSelection,
+        analyze_image_sequence, create_image_plan, filter_frames_at_fps,
+        filter_frames_with_masks_at_fps, prepare_image_sequence, FrameSelectionStrategy,
+        SmartFrameSelection,
     },
 };
 
@@ -90,7 +91,7 @@ async fn execute(cli: Cli) -> Result<()> {
                 create_image_plan(&analyze_image_sequence(&input)?, &quality.preset())
             } else {
                 let video = probe_video(&engines.ffprobe, &input, None).await?;
-                UniformRatioFrameSelection.create_plan(&video, &quality.preset())
+                SmartFrameSelection.create_plan(&video, &quality.preset())
             };
             println!("{}", serde_json::to_string_pretty(&plan)?);
         }
@@ -117,8 +118,8 @@ async fn execute(cli: Cli) -> Result<()> {
             ensure_engine(&engines.ffprobe)?;
             ensure_engine(&engines.ffmpeg)?;
             let video = probe_video(&engines.ffprobe, &input, None).await?;
-            let plan = UniformRatioFrameSelection.create_plan(&video, &quality.preset());
-            let extraction = extract_uniform_frames(
+            let plan = SmartFrameSelection.create_plan(&video, &quality.preset());
+            let mut extraction = extract_uniform_frames(
                 &engines.ffmpeg,
                 &input,
                 &output,
@@ -130,6 +131,34 @@ async fn execute(cli: Cli) -> Result<()> {
                 None,
             )
             .await?;
+            let filtered_output = output.with_file_name("frames.filtered");
+            let config = quality.preset().smart_filter_config;
+            let outcome = tokio::task::spawn_blocking({
+                let output = output.clone();
+                let filtered_output = filtered_output.clone();
+                let masks = masks.clone();
+                move || {
+                    if video.has_alpha {
+                        filter_frames_with_masks_at_fps(
+                            &output,
+                            &filtered_output,
+                            &masks,
+                            &config,
+                            plan.sampling_fps,
+                        )
+                    } else {
+                        filter_frames_at_fps(&output, &filtered_output, &config, plan.sampling_fps)
+                    }
+                }
+            })
+            .await
+            .map_err(|error| SplatError::Process(format!("智能抽帧过滤任务失败：{error}")))?
+            .map_err(|error| SplatError::Process(format!("智能抽帧过滤失败：{error}")))?;
+            replace_cli_filtered_frames(&output, &masks, &filtered_output, video.has_alpha).await?;
+            extraction.frame_count = outcome.kept_frames as u64;
+            if extraction.has_alpha {
+                extraction.mask_count = outcome.kept_frames as u64;
+            }
             if extraction.has_alpha {
                 println!(
                     "extracted {} RGBA frames to {} and {} masks to {}",
@@ -173,6 +202,64 @@ async fn execute(cli: Cli) -> Result<()> {
             println!("{}", serde_json::to_string_pretty(&result)?);
         }
     }
+    Ok(())
+}
+
+async fn replace_cli_filtered_frames(
+    frames: &std::path::Path,
+    masks: &std::path::Path,
+    filtered: &std::path::Path,
+    has_alpha: bool,
+) -> Result<()> {
+    let mut entries = tokio::fs::read_dir(frames).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        if entry.path().is_file()
+            && entry.path().extension().is_some_and(|ext| {
+                ext.eq_ignore_ascii_case("jpg")
+                    || ext.eq_ignore_ascii_case("jpeg")
+                    || ext.eq_ignore_ascii_case("png")
+            })
+        {
+            tokio::fs::remove_file(entry.path()).await?;
+        }
+    }
+    let mut kept = std::collections::HashSet::new();
+    let mut filtered_entries = tokio::fs::read_dir(filtered).await?;
+    while let Some(entry) = filtered_entries.next_entry().await? {
+        let source = entry.path();
+        let name = entry.file_name();
+        if source.is_file()
+            && source.extension().is_some_and(|ext| {
+                ext.eq_ignore_ascii_case("jpg")
+                    || ext.eq_ignore_ascii_case("jpeg")
+                    || ext.eq_ignore_ascii_case("png")
+            })
+        {
+            kept.insert(name.to_string_lossy().into_owned());
+            tokio::fs::copy(&source, frames.join(&name)).await?;
+        }
+    }
+    if has_alpha && masks.is_dir() {
+        let mut mask_entries = tokio::fs::read_dir(masks).await?;
+        while let Some(entry) = mask_entries.next_entry().await? {
+            if let Some(frame_name) = entry.file_name().to_string_lossy().strip_suffix(".png") {
+                if !kept.contains(frame_name) {
+                    tokio::fs::remove_file(entry.path()).await?;
+                }
+            }
+        }
+    }
+    for name in [
+        "metadata.csv",
+        "filter_summary.json",
+        "filter_forced_keep.log",
+    ] {
+        let source = filtered.join(name);
+        if source.is_file() {
+            tokio::fs::copy(&source, frames.join(name)).await?;
+        }
+    }
+    tokio::fs::remove_dir_all(filtered).await?;
     Ok(())
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -40,7 +40,7 @@ use crate::{
     },
     video::{
         analyze_image_sequence, create_image_plan, FramePlan, FrameSelectionStrategy,
-        ImageSequenceInfo, UniformRatioFrameSelection, VideoInfo,
+        ImageSequenceInfo, SmartFrameSelection, VideoInfo,
     },
 };
 
@@ -197,7 +197,7 @@ pub async fn probe_and_plan(
         })
     } else {
         let video = probe_video(&engine_paths.ffprobe, &input, None).await?;
-        let plan = UniformRatioFrameSelection.create_plan(&video, &quality.preset());
+        let plan = SmartFrameSelection.create_plan(&video, &quality.preset());
         let estimate = estimate_runtime(&video, &plan, quality, &samples);
         Ok(ProbeAndPlan {
             input_type: ProjectInputType::Video,
@@ -256,7 +256,7 @@ pub async fn estimate_project_runtime(
                 }
             };
             let plan = saved_plan.unwrap_or_else(|| {
-                UniformRatioFrameSelection.create_plan(&video, &metadata.quality.preset())
+                SmartFrameSelection.create_plan(&video, &metadata.quality.preset())
             });
             estimate_runtime(&video, &plan, metadata.quality, &samples)
         }

--- a/src-tauri/src/pipeline/runner.rs
+++ b/src-tauri/src/pipeline/runner.rs
@@ -36,8 +36,9 @@ use crate::{
         validator::{ReconstructionQuality, ReconstructionReport, ReconstructionValidator},
     },
     video::{
-        prepare_image_sequence, validate_prepared_image_sequence, FramePlan,
-        FrameSelectionStrategy, ImageSequenceInfo, UniformRatioFrameSelection, VideoInfo,
+        filter_frames_with_masks_at_fps, prepare_image_sequence, validate_prepared_image_sequence,
+        FrameFilterConfig, FramePlan, FrameSelectionStrategy, ImageSequenceInfo,
+        SmartFrameSelection, VideoInfo,
     },
 };
 
@@ -254,8 +255,8 @@ impl PipelineRunner {
             .stage(PipelineStage::ProbingVideo, 1.0, probe_message);
 
         self.events
-            .stage(PipelineStage::PlanningFrames, 0.0, "正在规划均匀抽帧");
-        let plan = UniformRatioFrameSelection.create_plan(&video, &quality.preset());
+            .stage(PipelineStage::PlanningFrames, 0.0, "正在规划智能抽帧");
+        let plan = SmartFrameSelection.create_plan(&video, &quality.preset());
         self.events.stage(
             PipelineStage::PlanningFrames,
             1.0,
@@ -277,7 +278,7 @@ impl PipelineRunner {
             Some(plan.estimated_frames),
             ObserverMode::Ffmpeg,
         );
-        let extraction = extract_uniform_frames(
+        let mut extraction = extract_uniform_frames(
             &self.engines.ffmpeg,
             input,
             output,
@@ -289,6 +290,39 @@ impl PipelineRunner {
             Some(observer),
         )
         .await?;
+        let filtered_output = output.with_file_name("frames.filtered");
+        if quality.preset().enable_smart_filter {
+            let config: FrameFilterConfig = quality.preset().smart_filter_config;
+            let input_for_filter = output.to_path_buf();
+            let output_for_filter = filtered_output.clone();
+            let masks_for_filter = masks.to_path_buf();
+            let sampling_fps = plan.sampling_fps;
+            let outcome = tokio::task::spawn_blocking(move || {
+                filter_frames_with_masks_at_fps(
+                    &input_for_filter,
+                    &output_for_filter,
+                    &masks_for_filter,
+                    &config,
+                    sampling_fps,
+                )
+            })
+            .await
+            .map_err(|error| SplatError::Process(format!("智能抽帧过滤任务失败：{error}")))?
+            .map_err(|error| SplatError::Process(format!("智能抽帧过滤失败：{error}")))?;
+            replace_filtered_frames(output, masks, &filtered_output, video.has_alpha).await?;
+            extraction.frame_count = outcome.kept_frames as u64;
+            if extraction.has_alpha {
+                extraction.mask_count = outcome.kept_frames as u64;
+            }
+            self.events.stage(
+                PipelineStage::ExtractingFrames,
+                1.0,
+                format!(
+                    "已智能筛选 {} / {} 帧",
+                    outcome.kept_frames, outcome.total_frames
+                ),
+            );
+        }
         self.events.stage(
             PipelineStage::ExtractingFrames,
             1.0,
@@ -1246,6 +1280,66 @@ fn best_sparse_model(frames: &Path, sparse: &Path) -> Result<(PathBuf, Reconstru
         }
     }
     best.ok_or_else(|| SplatError::Process("COLMAP 未生成完整的稀疏模型".into()))
+}
+
+/// 用智能过滤后的画面替换原始抽帧结果，并同步裁剪 Alpha Mask 与保留审计产物。
+async fn replace_filtered_frames(
+    frames: &Path,
+    masks: &Path,
+    filtered: &Path,
+    has_alpha: bool,
+) -> Result<()> {
+    let mut entries = tokio::fs::read_dir(frames).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        if entry.path().is_file()
+            && entry.path().extension().is_some_and(|ext| {
+                ext.eq_ignore_ascii_case("jpg")
+                    || ext.eq_ignore_ascii_case("jpeg")
+                    || ext.eq_ignore_ascii_case("png")
+            })
+        {
+            tokio::fs::remove_file(entry.path()).await?;
+        }
+    }
+    let mut kept_names = std::collections::HashSet::new();
+    let mut filtered_entries = tokio::fs::read_dir(filtered).await?;
+    while let Some(entry) = filtered_entries.next_entry().await? {
+        let source = entry.path();
+        let name = entry.file_name();
+        if source.is_file()
+            && source.extension().is_some_and(|ext| {
+                ext.eq_ignore_ascii_case("jpg")
+                    || ext.eq_ignore_ascii_case("jpeg")
+                    || ext.eq_ignore_ascii_case("png")
+            })
+        {
+            kept_names.insert(name.to_string_lossy().into_owned());
+            tokio::fs::copy(&source, frames.join(&name)).await?;
+        }
+    }
+    if has_alpha && masks.is_dir() {
+        let mut mask_entries = tokio::fs::read_dir(masks).await?;
+        while let Some(entry) = mask_entries.next_entry().await? {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if let Some(frame_name) = name.strip_suffix(".png") {
+                if !kept_names.contains(frame_name) {
+                    tokio::fs::remove_file(entry.path()).await?;
+                }
+            }
+        }
+    }
+    for name in [
+        "metadata.csv",
+        "filter_summary.json",
+        "filter_forced_keep.log",
+    ] {
+        let source = filtered.join(name);
+        if source.is_file() {
+            tokio::fs::copy(&source, frames.join(name)).await?;
+        }
+    }
+    tokio::fs::remove_dir_all(filtered).await?;
+    Ok(())
 }
 
 async fn prepare_brush_dataset(root: &Path, frames: &Path, model: &Path) -> Result<PathBuf> {

--- a/src-tauri/src/presets/quality.rs
+++ b/src-tauri/src/presets/quality.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
+use crate::video::FrameFilterConfig;
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum Quality {
@@ -15,6 +17,8 @@ pub struct QualityPreset {
     pub frame_retention_ratio: f64,
     pub brush_iterations: usize,
     pub brush_max_resolution: u32,
+    pub enable_smart_filter: bool,
+    pub smart_filter_config: FrameFilterConfig,
 }
 
 impl Quality {
@@ -24,16 +28,22 @@ impl Quality {
                 frame_retention_ratio: 0.30,
                 brush_iterations: 8_000,
                 brush_max_resolution: 1_200,
+                enable_smart_filter: true,
+                smart_filter_config: FrameFilterConfig::fast(),
             },
             Self::Balanced => QualityPreset {
                 frame_retention_ratio: 0.50,
                 brush_iterations: 15_000,
                 brush_max_resolution: 1_600,
+                enable_smart_filter: true,
+                smart_filter_config: FrameFilterConfig::balanced(),
             },
             Self::High => QualityPreset {
                 frame_retention_ratio: 1.00,
                 brush_iterations: 30_000,
                 brush_max_resolution: 2_000,
+                enable_smart_filter: true,
+                smart_filter_config: FrameFilterConfig::high(),
             },
         }
     }
@@ -73,6 +83,22 @@ mod tests {
         assert_eq!(Quality::High.preset().frame_retention_ratio, 1.00);
         assert_eq!(Quality::Fast.preset().brush_iterations, 8_000);
         assert_eq!(Quality::Balanced.preset().brush_max_resolution, 1_600);
+        assert!(Quality::Fast.preset().enable_smart_filter);
+        assert_eq!(
+            Quality::Fast.preset().smart_filter_config.keep_per_window,
+            2
+        );
+        assert_eq!(
+            Quality::Balanced
+                .preset()
+                .smart_filter_config
+                .keep_per_window,
+            3
+        );
+        assert_eq!(
+            Quality::High.preset().smart_filter_config.keep_per_window,
+            4
+        );
     }
 
     #[test]

--- a/src-tauri/src/video/frame_filter.rs
+++ b/src-tauri/src/video/frame_filter.rs
@@ -11,6 +11,10 @@ use serde::{Deserialize, Serialize};
 
 use super::image_sequence::is_image_file;
 
+/// 抽帧策略版本。任何改变筛选语义的改动都必须递增它，并写入 filter_summary.json，
+/// 使下游与断点续跑能够判断已有的审计产物是否由同一套策略生成。
+pub const FILTER_STRATEGY_VERSION: u32 = 1;
+
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FrameFilterConfig {
@@ -78,6 +82,7 @@ pub struct FrameMetrics {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FilterOutcome {
+    pub strategy_version: u32,
     pub total_frames: usize,
     pub kept_frames: usize,
     pub rejected_blur: usize,
@@ -193,6 +198,7 @@ fn filter_frames_impl(
     write_metadata(output_dir, &frames)?;
 
     let outcome = FilterOutcome {
+        strategy_version: FILTER_STRATEGY_VERSION,
         total_frames: frames.len(),
         kept_frames: frames.iter().filter(|frame| frame.metrics.kept).count(),
         rejected_blur: frames
@@ -442,7 +448,12 @@ fn decide_windows(frames: &mut [AnalyzedFrame], config: &FrameFilterConfig) {
             }
         }
     }
-    // 第二层兜底循环回填，直到所有相邻保留帧间隔都满足窗口上限。
+    backfill_gaps(frames, config);
+}
+
+/// 第二层兜底：回填相邻保留帧之间的 gap，直到不再存在超过 window_size 的间隔。
+/// 每轮取间隔区间内清晰度最高的一帧标记为 forced_keep，保证时序邻域不被拉断。
+fn backfill_gaps(frames: &mut [AnalyzedFrame], config: &FrameFilterConfig) {
     loop {
         let kept_indices = frames
             .iter()
@@ -455,8 +466,8 @@ fn decide_windows(frames: &mut [AnalyzedFrame], config: &FrameFilterConfig) {
         else {
             break;
         };
-        let range = pair[0] + 1..pair[1];
-        if let Some(index) = range.max_by(|left, right| {
+        let gap = pair[0] + 1..pair[1];
+        if let Some(index) = gap.max_by(|left, right| {
             frames[*left]
                 .metrics
                 .laplacian_variance
@@ -604,6 +615,51 @@ mod tests {
         assert!(csv
             .lines()
             .any(|line| line.contains("frame_000005.png") && line.contains(",false,exposure")));
+    }
+
+    #[test]
+    fn summary_records_the_strategy_version() {
+        let input = tempdir().unwrap();
+        let output = tempdir().unwrap();
+        save_frames(input.path(), 3, &[]);
+        let result = filter_frames(input.path(), output.path(), &config()).unwrap();
+        assert_eq!(result.strategy_version, FILTER_STRATEGY_VERSION);
+        let summary = fs::read_to_string(output.path().join("filter_summary.json")).unwrap();
+        assert!(summary.contains(&format!("\"strategyVersion\": {FILTER_STRATEGY_VERSION}")));
+    }
+
+    #[test]
+    fn all_blurred_windows_use_forced_keep() {
+        let input = tempdir().unwrap();
+        let output = tempdir().unwrap();
+        save_frames(input.path(), 20, &(1..=20).collect::<Vec<_>>());
+        let mut blurred_config = config();
+        blurred_config.blur_threshold = 1_000_000.0;
+
+        let result = filter_frames(input.path(), output.path(), &blurred_config).unwrap();
+        assert_eq!(result.kept_frames, 2);
+        let mut forced_log = fs::read_to_string(output.path().join("filter_forced_keep.log"))
+            .unwrap()
+            .lines()
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        let header = forced_log.remove(0);
+        assert_eq!(header, "显式 forced_keep 帧数：2");
+        let forced_numbers = forced_log
+            .iter()
+            .map(|name| frame_number(name))
+            .collect::<Vec<_>>();
+        assert_eq!(forced_numbers.len(), 2);
+        assert!((1..=10).contains(&forced_numbers[0]));
+        assert!((11..=20).contains(&forced_numbers[1]));
+        let metadata = fs::read_to_string(output.path().join("metadata.csv")).unwrap();
+        assert_eq!(
+            metadata
+                .lines()
+                .filter(|line| line.ends_with(",true,"))
+                .count(),
+            2
+        );
     }
 
     #[test]

--- a/src-tauri/src/video/frame_filter.rs
+++ b/src-tauri/src/video/frame_filter.rs
@@ -1,0 +1,659 @@
+use std::{
+    cmp::Ordering,
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use image::{imageops::FilterType, GenericImageView, GrayImage, ImageReader};
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use super::image_sequence::is_image_file;
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameFilterConfig {
+    pub blur_threshold: f64,
+    pub overexposure_ratio: f64,
+    pub underexposure_ratio: f64,
+    pub window_size: usize,
+    pub keep_per_window: usize,
+    pub analysis_max_edge: u32,
+    pub min_diff_score: f64,
+}
+
+impl FrameFilterConfig {
+    pub const fn fast() -> Self {
+        Self {
+            blur_threshold: 60.0,
+            overexposure_ratio: 0.02,
+            underexposure_ratio: 0.02,
+            window_size: 10,
+            keep_per_window: 2,
+            analysis_max_edge: 480,
+            min_diff_score: 0.02,
+        }
+    }
+
+    pub const fn balanced() -> Self {
+        Self {
+            blur_threshold: 100.0,
+            overexposure_ratio: 0.02,
+            underexposure_ratio: 0.02,
+            window_size: 10,
+            keep_per_window: 3,
+            analysis_max_edge: 480,
+            min_diff_score: 0.02,
+        }
+    }
+
+    pub const fn high() -> Self {
+        Self {
+            blur_threshold: 100.0,
+            overexposure_ratio: 0.02,
+            underexposure_ratio: 0.02,
+            window_size: 10,
+            keep_per_window: 4,
+            analysis_max_edge: 480,
+            min_diff_score: 0.02,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameMetrics {
+    pub frame_name: String,
+    pub timestamp_ms: u64,
+    pub laplacian_variance: f64,
+    pub overexposure_ratio: f64,
+    pub underexposure_ratio: f64,
+    pub diff_score: f64,
+    pub kept: bool,
+    pub reject_reason: Option<String>,
+    pub forced_keep: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FilterOutcome {
+    pub total_frames: usize,
+    pub kept_frames: usize,
+    pub rejected_blur: usize,
+    pub rejected_exposure: usize,
+    pub rejected_redundant: usize,
+    pub rejected_window_overflow: u32,
+    pub kept_file_names: Vec<String>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum FrameFilterError {
+    #[error("输入帧目录不存在：{0}")]
+    InputDirectory(PathBuf),
+    #[error("输入目录没有可处理的 JPG、JPEG 或 PNG 帧")]
+    NoFrames,
+    #[error("图像解码失败：{path}：{source}")]
+    Decode {
+        path: PathBuf,
+        source: image::ImageError,
+    },
+    #[error("帧过滤输出失败：{0}")]
+    Io(#[from] std::io::Error),
+    #[error("写入过滤摘要失败：{0}")]
+    Json(#[from] serde_json::Error),
+    #[error("配置无效：{0}")]
+    InvalidConfig(&'static str),
+}
+
+#[derive(Debug)]
+struct AnalyzedFrame {
+    path: PathBuf,
+    gray: GrayImage,
+    metrics: FrameMetrics,
+}
+
+pub fn filter_frames(
+    input_dir: &Path,
+    output_dir: &Path,
+    config: &FrameFilterConfig,
+) -> Result<FilterOutcome, FrameFilterError> {
+    filter_frames_at_fps(input_dir, output_dir, config, 1.0)
+}
+
+pub fn filter_frames_at_fps(
+    input_dir: &Path,
+    output_dir: &Path,
+    config: &FrameFilterConfig,
+    sampling_fps: f64,
+) -> Result<FilterOutcome, FrameFilterError> {
+    filter_frames_impl(input_dir, output_dir, config, None, sampling_fps)
+}
+
+pub fn filter_frames_with_masks(
+    input_dir: &Path,
+    output_dir: &Path,
+    mask_dir: &Path,
+    config: &FrameFilterConfig,
+) -> Result<FilterOutcome, FrameFilterError> {
+    filter_frames_with_masks_at_fps(input_dir, output_dir, mask_dir, config, 1.0)
+}
+
+pub fn filter_frames_with_masks_at_fps(
+    input_dir: &Path,
+    output_dir: &Path,
+    mask_dir: &Path,
+    config: &FrameFilterConfig,
+    sampling_fps: f64,
+) -> Result<FilterOutcome, FrameFilterError> {
+    filter_frames_impl(input_dir, output_dir, config, Some(mask_dir), sampling_fps)
+}
+
+fn filter_frames_impl(
+    input_dir: &Path,
+    output_dir: &Path,
+    config: &FrameFilterConfig,
+    mask_dir: Option<&Path>,
+    sampling_fps: f64,
+) -> Result<FilterOutcome, FrameFilterError> {
+    validate_config(config)?;
+    if !input_dir.is_dir() {
+        return Err(FrameFilterError::InputDirectory(input_dir.to_path_buf()));
+    }
+    let mut paths = fs::read_dir(input_dir)?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.is_file() && is_image_file(path))
+        .collect::<Vec<_>>();
+    paths.sort_by_key(|left| natural_name(left));
+    if paths.is_empty() {
+        return Err(FrameFilterError::NoFrames);
+    }
+
+    let mut frames = paths
+        .par_iter()
+        .map(|path| {
+            let frame_name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default();
+            let mask_path = mask_dir.and_then(|directory| {
+                let candidate = directory.join(format!("{frame_name}.png"));
+                candidate.is_file().then_some(candidate)
+            });
+            analyze_frame(path, config, mask_path.as_deref(), sampling_fps)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    decide_windows(&mut frames, config);
+    fs::create_dir_all(output_dir)?;
+    for frame in &frames {
+        if frame.metrics.kept {
+            fs::copy(&frame.path, output_dir.join(&frame.metrics.frame_name))?;
+        }
+    }
+    write_metadata(output_dir, &frames)?;
+
+    let outcome = FilterOutcome {
+        total_frames: frames.len(),
+        kept_frames: frames.iter().filter(|frame| frame.metrics.kept).count(),
+        rejected_blur: frames
+            .iter()
+            .filter(|frame| frame.metrics.reject_reason.as_deref() == Some("blur"))
+            .count(),
+        rejected_exposure: frames
+            .iter()
+            .filter(|frame| frame.metrics.reject_reason.as_deref() == Some("exposure"))
+            .count(),
+        rejected_redundant: frames
+            .iter()
+            .filter(|frame| frame.metrics.reject_reason.as_deref() == Some("redundant"))
+            .count(),
+        rejected_window_overflow: frames
+            .iter()
+            .filter(|frame| frame.metrics.reject_reason.as_deref() == Some("window_overflow"))
+            .count() as u32,
+        kept_file_names: frames
+            .iter()
+            .filter(|frame| frame.metrics.kept)
+            .map(|frame| frame.metrics.frame_name.clone())
+            .collect(),
+    };
+    fs::write(
+        output_dir.join("filter_summary.json"),
+        serde_json::to_vec_pretty(&outcome)?,
+    )?;
+    let forced = frames
+        .iter()
+        .filter(|frame| frame.metrics.forced_keep)
+        .count();
+    fs::write(
+        output_dir.join("filter_forced_keep.log"),
+        format!(
+            "显式 forced_keep 帧数：{forced}\n{}",
+            frames
+                .iter()
+                .filter(|frame| frame.metrics.forced_keep)
+                .map(|frame| frame.metrics.frame_name.as_str())
+                .collect::<Vec<_>>()
+                .join("\n")
+        ),
+    )?;
+    Ok(outcome)
+}
+
+fn validate_config(config: &FrameFilterConfig) -> Result<(), FrameFilterError> {
+    if config.window_size == 0 {
+        return Err(FrameFilterError::InvalidConfig("window_size 必须大于 0"));
+    }
+    if config.keep_per_window == 0 {
+        return Err(FrameFilterError::InvalidConfig(
+            "keep_per_window 必须大于 0",
+        ));
+    }
+    if config.analysis_max_edge == 0 {
+        return Err(FrameFilterError::InvalidConfig(
+            "analysis_max_edge 必须大于 0",
+        ));
+    }
+    if !(0.0..=1.0).contains(&config.overexposure_ratio)
+        || !(0.0..=1.0).contains(&config.underexposure_ratio)
+        || !(0.0..=1.0).contains(&config.min_diff_score)
+    {
+        return Err(FrameFilterError::InvalidConfig(
+            "比例和差异阈值必须位于 0..=1",
+        ));
+    }
+    Ok(())
+}
+
+fn analyze_frame(
+    path: &Path,
+    config: &FrameFilterConfig,
+    mask_path: Option<&Path>,
+    sampling_fps: f64,
+) -> Result<AnalyzedFrame, FrameFilterError> {
+    let image = ImageReader::open(path)
+        .map_err(|source| FrameFilterError::Decode {
+            path: path.to_path_buf(),
+            source: image::ImageError::IoError(source),
+        })?
+        .decode()
+        .map_err(|source| FrameFilterError::Decode {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let (width, height) = image.dimensions();
+    let scale = config.analysis_max_edge as f64 / width.max(height) as f64;
+    let gray = if scale < 1.0 {
+        image
+            .resize(
+                (width as f64 * scale).round().max(1.0) as u32,
+                (height as f64 * scale).round().max(1.0) as u32,
+                FilterType::Triangle,
+            )
+            .to_luma8()
+    } else {
+        image.to_luma8()
+    };
+    let visible = mask_path.and_then(|mask| {
+        ImageReader::open(mask)
+            .and_then(|reader| reader.decode().map_err(std::io::Error::other))
+            .ok()
+            .map(|mask| {
+                let mask = mask
+                    .resize_exact(gray.width(), gray.height(), FilterType::Nearest)
+                    .to_luma8();
+                mask.as_raw()
+                    .iter()
+                    .map(|&value| value > 0)
+                    .collect::<Vec<_>>()
+            })
+    });
+    let (laplacian_variance, overexposure_ratio, underexposure_ratio) =
+        gray_metrics(&gray, visible.as_deref());
+    let frame_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .to_owned();
+    Ok(AnalyzedFrame {
+        gray,
+        path: path.to_path_buf(),
+        metrics: FrameMetrics {
+            frame_name: frame_name.clone(),
+            timestamp_ms: ((frame_number(&frame_name).saturating_sub(1) as f64 * 1000.0
+                / sampling_fps.max(f64::EPSILON))
+            .round() as u64),
+            laplacian_variance,
+            overexposure_ratio,
+            underexposure_ratio,
+            diff_score: 1.0,
+            kept: false,
+            reject_reason: None,
+            forced_keep: false,
+        },
+    })
+}
+
+fn gray_metrics(gray: &GrayImage, visible: Option<&[bool]>) -> (f64, f64, f64) {
+    let pixels = gray.as_raw();
+    let indices = pixels
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| visible.is_none_or(|mask| mask.get(*index).copied().unwrap_or(false)));
+    let selected = indices.collect::<Vec<_>>();
+    let total = selected.len().max(1) as f64;
+    let over = selected.iter().filter(|(_, &value)| value > 250).count() as f64 / total;
+    let under = selected.iter().filter(|(_, &value)| value < 5).count() as f64 / total;
+    let mut responses = Vec::new();
+    if gray.width() >= 3 && gray.height() >= 3 {
+        for y in 1..gray.height() - 1 {
+            for x in 1..gray.width() - 1 {
+                let visible_at = |px: u32, py: u32| {
+                    visible.is_none_or(|mask| {
+                        mask.get((py * gray.width() + px) as usize)
+                            .copied()
+                            .unwrap_or(false)
+                    })
+                };
+                if !(visible_at(x, y)
+                    && visible_at(x - 1, y)
+                    && visible_at(x + 1, y)
+                    && visible_at(x, y - 1)
+                    && visible_at(x, y + 1))
+                {
+                    continue;
+                }
+                let center = gray.get_pixel(x, y)[0] as f64;
+                let neighbors = gray.get_pixel(x - 1, y)[0] as f64
+                    + gray.get_pixel(x + 1, y)[0] as f64
+                    + gray.get_pixel(x, y - 1)[0] as f64
+                    + gray.get_pixel(x, y + 1)[0] as f64;
+                responses.push(neighbors - 4.0 * center);
+            }
+        }
+    }
+    let mean = responses.iter().sum::<f64>() / responses.len().max(1) as f64;
+    let variance = responses
+        .iter()
+        .map(|value| (value - mean).powi(2))
+        .sum::<f64>()
+        / responses.len().max(1) as f64;
+    (variance, over, under)
+}
+
+fn decide_windows(frames: &mut [AnalyzedFrame], config: &FrameFilterConfig) {
+    // 下游 COLMAP 使用 sequential_matcher --SequentialMatching.overlap 10，依赖帧的时序邻域关系建立匹配图。若采用全局按质量排序取 Top-N，会抽出时间上跳跃的帧，导致匹配图断裂、mapper 分块失败，重建直接失败。
+    for window in frames.chunks_mut(config.window_size) {
+        let mut previous_kept: Option<GrayImage> = None;
+        let mut candidates = Vec::new();
+        for frame in window.iter_mut() {
+            if frame.metrics.laplacian_variance < config.blur_threshold {
+                frame.metrics.reject_reason = Some("blur".into());
+            } else if frame.metrics.overexposure_ratio > config.overexposure_ratio
+                || frame.metrics.underexposure_ratio > config.underexposure_ratio
+            {
+                frame.metrics.reject_reason = Some("exposure".into());
+            } else {
+                frame.metrics.diff_score = previous_kept.as_ref().map_or(1.0, |previous| {
+                    mean_absolute_difference(previous, &frame.gray)
+                });
+                if candidates.is_empty() {
+                    frame.metrics.kept = true;
+                    previous_kept = Some(frame.gray.clone());
+                    candidates.push(frame);
+                } else if frame.metrics.diff_score < config.min_diff_score {
+                    frame.metrics.reject_reason = Some("redundant".into());
+                } else {
+                    frame.metrics.kept = true;
+                    previous_kept = Some(frame.gray.clone());
+                    candidates.push(frame);
+                }
+            }
+        }
+        if candidates.len() > config.keep_per_window {
+            // 窗口首个合格帧是时序锚点，必须保留；只在其余候选中按清晰度淘汰。
+            let first_name = candidates[0].metrics.frame_name.clone();
+            candidates[1..].sort_by(|left, right| {
+                right
+                    .metrics
+                    .laplacian_variance
+                    .partial_cmp(&left.metrics.laplacian_variance)
+                    .unwrap_or(Ordering::Equal)
+            });
+            for frame in candidates
+                .into_iter()
+                .filter(|frame| frame.metrics.frame_name != first_name)
+                .skip(config.keep_per_window.saturating_sub(1))
+            {
+                frame.metrics.kept = false;
+                frame.metrics.reject_reason = Some("window_overflow".into());
+            }
+        }
+        if !window.iter().any(|frame| frame.metrics.kept) {
+            if let Some(frame) = window.iter_mut().max_by(|left, right| {
+                left.metrics
+                    .laplacian_variance
+                    .partial_cmp(&right.metrics.laplacian_variance)
+                    .unwrap_or(Ordering::Equal)
+            }) {
+                frame.metrics.kept = true;
+                frame.metrics.forced_keep = true;
+                frame.metrics.reject_reason = None;
+            }
+        }
+    }
+    // 第二层兜底循环回填，直到所有相邻保留帧间隔都满足窗口上限。
+    loop {
+        let kept_indices = frames
+            .iter()
+            .enumerate()
+            .filter_map(|(index, frame)| frame.metrics.kept.then_some(index))
+            .collect::<Vec<_>>();
+        let Some(pair) = kept_indices
+            .windows(2)
+            .find(|pair| pair[1] - pair[0] > config.window_size)
+        else {
+            break;
+        };
+        let range = pair[0] + 1..pair[1];
+        if let Some(index) = range.max_by(|left, right| {
+            frames[*left]
+                .metrics
+                .laplacian_variance
+                .partial_cmp(&frames[*right].metrics.laplacian_variance)
+                .unwrap_or(Ordering::Equal)
+        }) {
+            frames[index].metrics.kept = true;
+            frames[index].metrics.forced_keep = true;
+            frames[index].metrics.reject_reason = None;
+        } else {
+            break;
+        }
+    }
+}
+
+fn mean_absolute_difference(left: &GrayImage, right: &GrayImage) -> f64 {
+    if left.dimensions() != right.dimensions() {
+        return 1.0;
+    }
+    left.as_raw()
+        .iter()
+        .zip(right.as_raw())
+        .map(|(a, b)| (*a as f64 - *b as f64).abs() / 255.0)
+        .sum::<f64>()
+        / left.as_raw().len().max(1) as f64
+}
+
+fn write_metadata(output_dir: &Path, frames: &[AnalyzedFrame]) -> Result<(), FrameFilterError> {
+    let mut file = fs::File::create(output_dir.join("metadata.csv"))?;
+    writeln!(file, "frame_name,timestamp_ms,laplacian_variance,overexposure_ratio,underexposure_ratio,diff_score,kept,reject_reason")?;
+    for frame in frames {
+        writeln!(
+            file,
+            "{},{},{:.6},{:.6},{:.6},{:.6},{},{}",
+            csv_escape(&frame.metrics.frame_name),
+            frame.metrics.timestamp_ms,
+            frame.metrics.laplacian_variance,
+            frame.metrics.overexposure_ratio,
+            frame.metrics.underexposure_ratio,
+            frame.metrics.diff_score,
+            frame.metrics.kept,
+            frame
+                .metrics
+                .reject_reason
+                .as_deref()
+                .map(csv_escape)
+                .unwrap_or_default()
+        )?;
+    }
+    Ok(())
+}
+
+fn csv_escape(value: &str) -> String {
+    if value.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_owned()
+    }
+}
+fn natural_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+}
+fn frame_number(name: &str) -> u64 {
+    name.strip_suffix(".jpg")
+        .or_else(|| name.strip_suffix(".jpeg"))
+        .or_else(|| name.strip_suffix(".png"))
+        .unwrap_or(name)
+        .rsplit_once('_')
+        .and_then(|(_, value)| value.parse().ok())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{ImageBuffer, Luma};
+    use tempfile::tempdir;
+
+    fn config() -> FrameFilterConfig {
+        FrameFilterConfig {
+            blur_threshold: 60.0,
+            overexposure_ratio: 0.95,
+            underexposure_ratio: 0.95,
+            window_size: 10,
+            keep_per_window: 3,
+            analysis_max_edge: 64,
+            min_diff_score: 0.01,
+        }
+    }
+    fn textured(index: u32, blurred: bool) -> ImageBuffer<Luma<u8>, Vec<u8>> {
+        let image = ImageBuffer::from_fn(64, 64, |x, y| {
+            let checker = ((x / 8 + y / 8) % 2) * 100;
+            Luma([(checker + ((x * 17 + y * 13 + index * 3) % 100)) as u8])
+        });
+        if blurred {
+            image::imageops::blur(&image, 5.0)
+        } else {
+            image
+        }
+    }
+    fn save_frames(dir: &Path, count: u32, blur_indices: &[u32]) {
+        for index in 1..=count {
+            textured(index, blur_indices.contains(&index))
+                .save(dir.join(format!("frame_{index:06}.jpg")))
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn blur_is_rejected() {
+        let input = tempdir().unwrap();
+        let output = tempdir().unwrap();
+        save_frames(input.path(), 20, &[7, 13]);
+        let result = filter_frames(input.path(), output.path(), &config()).unwrap();
+        let metadata = fs::read_to_string(output.path().join("metadata.csv")).unwrap();
+        let rows = metadata.lines().skip(1).collect::<Vec<_>>();
+        assert_eq!(rows.len(), 20);
+        assert!(result.rejected_blur >= 2);
+        assert!(rows[6].contains(",false,blur"));
+        assert!(rows[12].contains(",false,blur"));
+    }
+
+    #[test]
+    fn exposure_is_rejected() {
+        let input = tempdir().unwrap();
+        let output = tempdir().unwrap();
+        for index in 1..=10 {
+            let image = ImageBuffer::from_pixel(
+                32,
+                32,
+                Luma([if index == 5 { 255 } else { (index * 10) as u8 }]),
+            );
+            image
+                .save(input.path().join(format!("frame_{index:06}.png")))
+                .unwrap();
+        }
+        let mut exposure_config = config();
+        exposure_config.blur_threshold = -1.0;
+        let result = filter_frames(input.path(), output.path(), &exposure_config).unwrap();
+        assert!(result.rejected_exposure >= 1);
+        let csv = fs::read_to_string(output.path().join("metadata.csv")).unwrap();
+        assert!(csv
+            .lines()
+            .any(|line| line.contains("frame_000005.png") && line.contains(",false,exposure")));
+    }
+
+    #[test]
+    fn redundant_frames_are_bounded_by_windows() {
+        let input = tempdir().unwrap();
+        let output = tempdir().unwrap();
+        for index in 1..=20 {
+            textured(1, false)
+                .save(input.path().join(format!("frame_{index:06}.jpg")))
+                .unwrap();
+        }
+        let result = filter_frames(input.path(), output.path(), &config()).unwrap();
+        assert!(result.kept_frames <= 2 * config().keep_per_window);
+    }
+
+    #[test]
+    fn retained_indices_are_strictly_increasing_and_have_no_window_hole() {
+        let input = tempdir().unwrap();
+        let output = tempdir().unwrap();
+        save_frames(input.path(), 30, &[2, 3, 12, 13, 22]);
+        let result = filter_frames(input.path(), output.path(), &config()).unwrap();
+        let indices = result
+            .kept_file_names
+            .iter()
+            .map(|name| frame_number(name))
+            .collect::<Vec<_>>();
+        assert!(indices
+            .windows(2)
+            .all(|pair| pair[0] < pair[1] && pair[1] - pair[0] <= config().window_size as u64));
+    }
+
+    #[test]
+    fn noise_has_higher_laplacian_variance_than_solid_color() {
+        let solid = ImageBuffer::from_pixel(64, 64, Luma([100]));
+        let noisy = textured(4, false);
+        assert!(gray_metrics(&noisy, None).0 > gray_metrics(&solid, None).0 * 3.0);
+    }
+
+    #[test]
+    fn metadata_contains_one_row_per_input_frame() {
+        let input = tempdir().unwrap();
+        let output = tempdir().unwrap();
+        save_frames(input.path(), 20, &[]);
+        filter_frames(input.path(), output.path(), &config()).unwrap();
+        assert_eq!(
+            fs::read_to_string(output.path().join("metadata.csv"))
+                .unwrap()
+                .lines()
+                .count(),
+            21
+        );
+    }
+}

--- a/src-tauri/src/video/frame_filter.rs
+++ b/src-tauri/src/video/frame_filter.rs
@@ -13,7 +13,8 @@ use super::image_sequence::is_image_file;
 
 /// 抽帧策略版本。任何改变筛选语义的改动都必须递增它，并写入 filter_summary.json，
 /// 使下游与断点续跑能够判断已有的审计产物是否由同一套策略生成。
-pub const FILTER_STRATEGY_VERSION: u32 = 1;
+/// v2：曝光改为「序列自适应门限 + 配额保底」，绝对阈值由 0.02 校准到 0.55，裁切判定改为 >=254 / <=1。
+pub const FILTER_STRATEGY_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -21,6 +22,10 @@ pub struct FrameFilterConfig {
     pub blur_threshold: f64,
     pub overexposure_ratio: f64,
     pub underexposure_ratio: f64,
+    /// 曝光离群裕度：门限取 `max(绝对阈值, 本序列中位数 + 该裕度)`。
+    /// 整段素材本身就偏亮/偏暗时，绝对阈值会把每一帧都判成曝光异常，
+    /// 加入该裕度后只有明显异于同段素材的帧（闪光、对着灯拍）才算异常。
+    pub exposure_outlier_margin: f64,
     pub window_size: usize,
     pub keep_per_window: usize,
     pub analysis_max_edge: u32,
@@ -31,8 +36,9 @@ impl FrameFilterConfig {
     pub const fn fast() -> Self {
         Self {
             blur_threshold: 60.0,
-            overexposure_ratio: 0.02,
-            underexposure_ratio: 0.02,
+            overexposure_ratio: 0.55,
+            underexposure_ratio: 0.55,
+            exposure_outlier_margin: 0.3,
             window_size: 10,
             keep_per_window: 2,
             analysis_max_edge: 480,
@@ -43,8 +49,9 @@ impl FrameFilterConfig {
     pub const fn balanced() -> Self {
         Self {
             blur_threshold: 100.0,
-            overexposure_ratio: 0.02,
-            underexposure_ratio: 0.02,
+            overexposure_ratio: 0.55,
+            underexposure_ratio: 0.55,
+            exposure_outlier_margin: 0.3,
             window_size: 10,
             keep_per_window: 3,
             analysis_max_edge: 480,
@@ -55,8 +62,9 @@ impl FrameFilterConfig {
     pub const fn high() -> Self {
         Self {
             blur_threshold: 100.0,
-            overexposure_ratio: 0.02,
-            underexposure_ratio: 0.02,
+            overexposure_ratio: 0.55,
+            underexposure_ratio: 0.55,
+            exposure_outlier_margin: 0.3,
             window_size: 10,
             keep_per_window: 4,
             analysis_max_edge: 480,
@@ -85,10 +93,13 @@ pub struct FilterOutcome {
     pub strategy_version: u32,
     pub total_frames: usize,
     pub kept_frames: usize,
+    /// 质量门（blur/exposure）或配额淘汰拦下、且最终确实未保留的帧数。
     pub rejected_blur: usize,
     pub rejected_exposure: usize,
     pub rejected_redundant: usize,
     pub rejected_window_overflow: u32,
+    /// 由兜底逻辑（配额保底 / 第一层兜底 / 跨窗口回填）保留的帧数。
+    pub forced_keeps: usize,
     pub kept_file_names: Vec<String>,
 }
 
@@ -201,22 +212,15 @@ fn filter_frames_impl(
         strategy_version: FILTER_STRATEGY_VERSION,
         total_frames: frames.len(),
         kept_frames: frames.iter().filter(|frame| frame.metrics.kept).count(),
-        rejected_blur: frames
+        // 统计口径按最终决策：被保底回填而保留的帧，即便先前打上过 reject_reason，也算保留而非拒绝。
+        rejected_blur: count_rejected(&frames, "blur"),
+        rejected_exposure: count_rejected(&frames, "exposure"),
+        rejected_redundant: count_rejected(&frames, "redundant"),
+        rejected_window_overflow: count_rejected(&frames, "window_overflow") as u32,
+        forced_keeps: frames
             .iter()
-            .filter(|frame| frame.metrics.reject_reason.as_deref() == Some("blur"))
+            .filter(|frame| frame.metrics.forced_keep)
             .count(),
-        rejected_exposure: frames
-            .iter()
-            .filter(|frame| frame.metrics.reject_reason.as_deref() == Some("exposure"))
-            .count(),
-        rejected_redundant: frames
-            .iter()
-            .filter(|frame| frame.metrics.reject_reason.as_deref() == Some("redundant"))
-            .count(),
-        rejected_window_overflow: frames
-            .iter()
-            .filter(|frame| frame.metrics.reject_reason.as_deref() == Some("window_overflow"))
-            .count() as u32,
         kept_file_names: frames
             .iter()
             .filter(|frame| frame.metrics.kept)
@@ -348,8 +352,10 @@ fn gray_metrics(gray: &GrayImage, visible: Option<&[bool]>) -> (f64, f64, f64) {
         .filter(|(index, _)| visible.is_none_or(|mask| mask.get(*index).copied().unwrap_or(false)));
     let selected = indices.collect::<Vec<_>>();
     let total = selected.len().max(1) as f64;
-    let over = selected.iter().filter(|(_, &value)| value > 250).count() as f64 / total;
-    let under = selected.iter().filter(|(_, &value)| value < 5).count() as f64 / total;
+    // 只统计真正被裁切的像素：>=254 是 8bit 下的近裁切，<=1 是近全黑。
+    // 早期用 >250 会把「曝光正常的白布景/雪景」也算成裁切，导致整段素材被误拒。
+    let over = selected.iter().filter(|(_, &value)| value >= 254).count() as f64 / total;
+    let under = selected.iter().filter(|(_, &value)| value <= 1).count() as f64 / total;
     let mut responses = Vec::new();
     if gray.width() >= 3 && gray.height() >= 3 {
         for y in 1..gray.height() - 1 {
@@ -389,66 +395,136 @@ fn gray_metrics(gray: &GrayImage, visible: Option<&[bool]>) -> (f64, f64, f64) {
 
 fn decide_windows(frames: &mut [AnalyzedFrame], config: &FrameFilterConfig) {
     // 下游 COLMAP 使用 sequential_matcher --SequentialMatching.overlap 10，依赖帧的时序邻域关系建立匹配图。若采用全局按质量排序取 Top-N，会抽出时间上跳跃的帧，导致匹配图断裂、mapper 分块失败，重建直接失败。
+    let (over_gate, under_gate) = adaptive_exposure_gates(frames, config);
     for window in frames.chunks_mut(config.window_size) {
-        let mut previous_kept: Option<GrayImage> = None;
-        let mut candidates = Vec::new();
+        // 1) 质量门。曝光先判：真正被裁切的帧应记 exposure，
+        //    否则一张全白帧会因为均匀图拉普拉斯方差为 0 而被记成 blur，审计原因误导排查。
         for frame in window.iter_mut() {
-            if frame.metrics.laplacian_variance < config.blur_threshold {
-                frame.metrics.reject_reason = Some("blur".into());
-            } else if frame.metrics.overexposure_ratio > config.overexposure_ratio
-                || frame.metrics.underexposure_ratio > config.underexposure_ratio
+            if frame.metrics.overexposure_ratio > over_gate
+                || frame.metrics.underexposure_ratio > under_gate
             {
                 frame.metrics.reject_reason = Some("exposure".into());
-            } else {
-                frame.metrics.diff_score = previous_kept.as_ref().map_or(1.0, |previous| {
-                    mean_absolute_difference(previous, &frame.gray)
-                });
-                if candidates.is_empty() {
-                    frame.metrics.kept = true;
-                    previous_kept = Some(frame.gray.clone());
-                    candidates.push(frame);
-                } else if frame.metrics.diff_score < config.min_diff_score {
-                    frame.metrics.reject_reason = Some("redundant".into());
-                } else {
-                    frame.metrics.kept = true;
-                    previous_kept = Some(frame.gray.clone());
-                    candidates.push(frame);
-                }
+            } else if frame.metrics.laplacian_variance < config.blur_threshold {
+                frame.metrics.reject_reason = Some("blur".into());
             }
         }
-        if candidates.len() > config.keep_per_window {
-            // 窗口首个合格帧是时序锚点，必须保留；只在其余候选中按清晰度淘汰。
-            let first_name = candidates[0].metrics.frame_name.clone();
-            candidates[1..].sort_by(|left, right| {
-                right
+        // 2) 合格帧的时序冗余筛选，参考帧是窗口内上一张保留帧。
+        let mut previous_kept: Option<GrayImage> = None;
+        let mut qualified: Vec<usize> = Vec::new();
+        for (index, frame) in window.iter_mut().enumerate() {
+            if frame.metrics.reject_reason.is_some() {
+                continue;
+            }
+            let diff = previous_kept.as_ref().map_or(1.0, |previous| {
+                mean_absolute_difference(previous, &frame.gray)
+            });
+            frame.metrics.diff_score = diff;
+            if qualified.is_empty() || diff >= config.min_diff_score {
+                frame.metrics.kept = true;
+                previous_kept = Some(frame.gray.clone());
+                qualified.push(index);
+            } else {
+                frame.metrics.reject_reason = Some("redundant".into());
+            }
+        }
+        // 3) 配额内按清晰度淘汰：窗口首个合格帧是时序锚点，必须保留，只在其余候选中淘汰。
+        if qualified.len() > config.keep_per_window {
+            let mut rest = qualified[1..].to_vec();
+            rest.sort_by(|left, right| {
+                window[*right]
                     .metrics
                     .laplacian_variance
-                    .partial_cmp(&left.metrics.laplacian_variance)
+                    .partial_cmp(&window[*left].metrics.laplacian_variance)
                     .unwrap_or(Ordering::Equal)
             });
-            for frame in candidates
+            for index in rest
                 .into_iter()
-                .filter(|frame| frame.metrics.frame_name != first_name)
                 .skip(config.keep_per_window.saturating_sub(1))
             {
-                frame.metrics.kept = false;
-                frame.metrics.reject_reason = Some("window_overflow".into());
+                window[index].metrics.kept = false;
+                window[index].metrics.reject_reason = Some("window_overflow".into());
             }
         }
-        if !window.iter().any(|frame| frame.metrics.kept) {
-            if let Some(frame) = window.iter_mut().max_by(|left, right| {
-                left.metrics
+        // 4) 配额保底：被曝光门裁掉、但仍保留可用细节的帧，按清晰度回填到配额。
+        //    重建需要足够的视角覆盖，所以宁可多几帧近似重复，也不让窗口塌成「每窗一帧」。
+        //    低细节帧（blur）不参与回填——无纹理帧补进来对匹配没有帮助，仍由第一层兜底保证至少一帧。
+        let kept_now = window.iter().filter(|frame| frame.metrics.kept).count();
+        if kept_now < config.keep_per_window {
+            let mut deficit = config.keep_per_window - kept_now;
+            let mut pool = (0..window.len())
+                .filter(|index| {
+                    let frame = &window[*index];
+                    !frame.metrics.kept
+                        && frame.metrics.reject_reason.as_deref() == Some("exposure")
+                        && frame.metrics.laplacian_variance >= config.blur_threshold
+                })
+                .collect::<Vec<_>>();
+            pool.sort_by(|left, right| {
+                window[*right]
+                    .metrics
                     .laplacian_variance
-                    .partial_cmp(&right.metrics.laplacian_variance)
+                    .partial_cmp(&window[*left].metrics.laplacian_variance)
                     .unwrap_or(Ordering::Equal)
-            }) {
-                frame.metrics.kept = true;
-                frame.metrics.forced_keep = true;
-                frame.metrics.reject_reason = None;
+            });
+            for index in pool {
+                if deficit == 0 {
+                    break;
+                }
+                window[index].metrics.kept = true;
+                window[index].metrics.forced_keep = true;
+                window[index].metrics.reject_reason = None;
+                deficit -= 1;
+            }
+        }
+        // 5) 第一层兜底：整窗没有任何保留帧时，保留清晰度最高的那一帧。
+        if !window.iter().any(|frame| frame.metrics.kept) {
+            if let Some(index) = best_laplacian_index(window) {
+                window[index].metrics.kept = true;
+                window[index].metrics.forced_keep = true;
+                window[index].metrics.reject_reason = None;
             }
         }
     }
     backfill_gaps(frames, config);
+}
+
+/// 曝光门限取「绝对阈值」与「本序列中位数 + 离群裕度」中更宽松的一个：
+/// 整段素材本身偏亮/偏暗时，绝对阈值会把每一帧都判成异常，只有真正异于同段素材的帧（闪光、对着灯拍）才该剔除。
+fn adaptive_exposure_gates(frames: &[AnalyzedFrame], config: &FrameFilterConfig) -> (f64, f64) {
+    let over = median(frames.iter().map(|frame| frame.metrics.overexposure_ratio));
+    let under = median(frames.iter().map(|frame| frame.metrics.underexposure_ratio));
+    (
+        config
+            .overexposure_ratio
+            .max(over + config.exposure_outlier_margin),
+        config
+            .underexposure_ratio
+            .max(under + config.exposure_outlier_margin),
+    )
+}
+
+fn median(values: impl Iterator<Item = f64>) -> f64 {
+    let mut sorted = values.collect::<Vec<_>>();
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    sorted.sort_by(|left, right| left.partial_cmp(right).unwrap_or(Ordering::Equal));
+    let middle = sorted.len() / 2;
+    if sorted.len() % 2 == 0 {
+        (sorted[middle - 1] + sorted[middle]) / 2.0
+    } else {
+        sorted[middle]
+    }
+}
+
+fn best_laplacian_index(window: &[AnalyzedFrame]) -> Option<usize> {
+    (0..window.len()).max_by(|left, right| {
+        window[*left]
+            .metrics
+            .laplacian_variance
+            .partial_cmp(&window[*right].metrics.laplacian_variance)
+            .unwrap_or(Ordering::Equal)
+    })
 }
 
 /// 第二层兜底：回填相邻保留帧之间的 gap，直到不再存在超过 window_size 的间隔。
@@ -493,6 +569,15 @@ fn mean_absolute_difference(left: &GrayImage, right: &GrayImage) -> f64 {
         .map(|(a, b)| (*a as f64 - *b as f64).abs() / 255.0)
         .sum::<f64>()
         / left.as_raw().len().max(1) as f64
+}
+
+fn count_rejected(frames: &[AnalyzedFrame], reason: &str) -> usize {
+    frames
+        .iter()
+        .filter(|frame| {
+            !frame.metrics.kept && frame.metrics.reject_reason.as_deref() == Some(reason)
+        })
+        .count()
 }
 
 fn write_metadata(output_dir: &Path, frames: &[AnalyzedFrame]) -> Result<(), FrameFilterError> {
@@ -552,8 +637,9 @@ mod tests {
     fn config() -> FrameFilterConfig {
         FrameFilterConfig {
             blur_threshold: 60.0,
-            overexposure_ratio: 0.95,
-            underexposure_ratio: 0.95,
+            overexposure_ratio: 0.55,
+            underexposure_ratio: 0.55,
+            exposure_outlier_margin: 0.3,
             window_size: 10,
             keep_per_window: 3,
             analysis_max_edge: 64,
@@ -577,6 +663,88 @@ mod tests {
                 .save(dir.join(format!("frame_{index:06}.jpg")))
                 .unwrap();
         }
+    }
+    fn save_png(dir: &Path, index: u32, image: &ImageBuffer<Luma<u8>, Vec<u8>>) {
+        image
+            .save(dir.join(format!("frame_{index:06}.png")))
+            .unwrap();
+    }
+
+    /// 白布景 + 移动的暗色物体：3DGS 实物扫描的常见布景。
+    /// 曝光完全正常，但白色像素占比极高——旧版绝对阈值会把它整段判成曝光异常。
+    fn bright_backdrop(index: u32) -> ImageBuffer<Luma<u8>, Vec<u8>> {
+        ImageBuffer::from_fn(64, 64, |x, y| {
+            let shift = (index * 5) % 48;
+            if (shift..shift + 12).contains(&x) && (20..44).contains(&y) {
+                Luma([0])
+            } else {
+                Luma([255])
+            }
+        })
+    }
+
+    /// 超出序列曝光门限、但边缘细节充足（能用于匹配）的帧。
+    fn overexposed_but_detailed(index: u32) -> ImageBuffer<Luma<u8>, Vec<u8>> {
+        ImageBuffer::from_fn(64, 64, |x, y| {
+            if x < 13 {
+                let shifted = (x + index) % 13;
+                if (shifted / 3 + y / 3).is_multiple_of(2) {
+                    Luma([255])
+                } else {
+                    Luma([0])
+                }
+            } else {
+                Luma([255])
+            }
+        })
+    }
+
+    /// 曝光正常、同样有充足细节的对照帧。
+    fn normal_but_detailed(index: u32) -> ImageBuffer<Luma<u8>, Vec<u8>> {
+        ImageBuffer::from_fn(64, 64, |x, y| {
+            if x < 13 {
+                let shifted = (x + index) % 13;
+                if (shifted / 3 + y / 3).is_multiple_of(2) {
+                    Luma([120])
+                } else {
+                    Luma([20])
+                }
+            } else {
+                Luma([60])
+            }
+        })
+    }
+
+    #[test]
+    fn bright_backdrop_is_not_mass_rejected() {
+        let input = tempdir().unwrap();
+        let output = tempdir().unwrap();
+        for index in 1..=20 {
+            save_png(input.path(), index, &bright_backdrop(index));
+        }
+        let result = filter_frames(input.path(), output.path(), &config()).unwrap();
+        // 自适应门限：整段都白，就没有任何一帧是"异常亮"，一帧都不该因曝光被拒。
+        assert_eq!(result.rejected_exposure, 0);
+        // 保留量应达到配额，而不是塌成"每窗一帧"。
+        assert_eq!(result.kept_frames, 2 * config().keep_per_window);
+        assert_eq!(result.forced_keeps, 0);
+    }
+
+    #[test]
+    fn exposure_gate_backfills_the_window_quota() {
+        let input = tempdir().unwrap();
+        let output = tempdir().unwrap();
+        for index in 1..=10 {
+            save_png(input.path(), index, &overexposed_but_detailed(index));
+        }
+        for index in 11..=20 {
+            save_png(input.path(), index, &normal_but_detailed(index));
+        }
+        let result = filter_frames(input.path(), output.path(), &config()).unwrap();
+        // 第一个窗口整窗被曝光门拦下，但帧本身细节充足：应回填到配额，而不是只留一帧。
+        assert_eq!(result.kept_frames, 2 * config().keep_per_window);
+        assert_eq!(result.forced_keeps, config().keep_per_window);
+        assert_eq!(result.rejected_exposure, 10 - config().keep_per_window);
     }
 
     #[test]

--- a/src-tauri/src/video/frame_plan.rs
+++ b/src-tauri/src/video/frame_plan.rs
@@ -17,6 +17,26 @@ pub trait FrameSelectionStrategy {
 #[derive(Debug, Default, Clone, Copy)]
 pub struct UniformRatioFrameSelection;
 
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SmartFrameSelection;
+
+impl FrameSelectionStrategy for SmartFrameSelection {
+    fn create_plan(&self, video: &VideoInfo, preset: &QualityPreset) -> FramePlan {
+        // 智能过滤发生在 FFmpeg 抽帧之后；先按 1.5 倍超采样，给质量过滤留下足够候选帧。
+        // 过滤可能剔除模糊、曝光异常和时序冗余帧，超采样可避免有效帧数量不足。
+        const OVERSAMPLE_FACTOR: f64 = 1.5;
+        let sampling_fps =
+            (video.fps * preset.frame_retention_ratio * OVERSAMPLE_FACTOR).min(video.fps);
+        FramePlan {
+            retention_ratio: preset.frame_retention_ratio,
+            sampling_fps,
+            estimated_frames: (video.total_frames as f64
+                * (sampling_fps / video.fps.max(f64::EPSILON)))
+            .round() as u64,
+        }
+    }
+}
+
 impl FrameSelectionStrategy for UniformRatioFrameSelection {
     fn create_plan(&self, video: &VideoInfo, preset: &QualityPreset) -> FramePlan {
         FramePlan {
@@ -32,6 +52,14 @@ impl FrameSelectionStrategy for UniformRatioFrameSelection {
 mod tests {
     use super::*;
     use crate::presets::Quality;
+
+    #[test]
+    fn smart_selection_oversamples_for_post_filtering() {
+        let plan =
+            SmartFrameSelection.create_plan(&thirty_fps_video(), &Quality::Balanced.preset());
+        assert_eq!(plan.sampling_fps, 22.5);
+        assert_eq!(plan.estimated_frames, 1_350);
+    }
 
     fn thirty_fps_video() -> VideoInfo {
         VideoInfo {

--- a/src-tauri/src/video/mod.rs
+++ b/src-tauri/src/video/mod.rs
@@ -1,9 +1,16 @@
 pub mod extract;
+pub mod frame_filter;
 pub mod frame_plan;
 pub mod image_sequence;
 pub mod probe;
 
-pub use frame_plan::{FramePlan, FrameSelectionStrategy, UniformRatioFrameSelection};
+pub use frame_filter::{
+    filter_frames, filter_frames_at_fps, filter_frames_with_masks, filter_frames_with_masks_at_fps,
+    FilterOutcome, FrameFilterConfig, FrameFilterError, FrameMetrics,
+};
+pub use frame_plan::{
+    FramePlan, FrameSelectionStrategy, SmartFrameSelection, UniformRatioFrameSelection,
+};
 pub use image_sequence::{
     analyze_image_sequence, create_plan as create_image_plan, is_image_file, list_images,
     normalized_image_name, prepare_image_sequence, validate_prepared_image_sequence,


### PR DESCRIPTION
## 修改内容

新增智能抽帧（帧质量筛选）模块，替代原先“按视频 FPS × 保留比例均匀抽帧”的行为。

- 新增 `src-tauri/src/video/frame_filter.rs`：
  - `FrameFilterConfig` / `FrameMetrics` / `FilterOutcome` / `FrameFilterError`
  - `filter_frames()`（以及带 Alpha Mask 与采样 FPS 的变体）
  - 在降采样灰度图上计算：3×3 拉普拉斯方差、**近裁切（≥254）与近全黑（≤1）像素比例**、与上一张**保留帧**的平均绝对差 `diff_score`
  - 曝光门限取 `max(绝对阈值, 本序列中位数 + 离群裕度)`：整段素材本身偏亮/偏暗时，没有哪一帧是“异常亮”，不会逐帧误判（本 PR 关键修复，见下）
  - 按 `window_size` 连续窗口切分，窗口内依次执行：曝光门 → 模糊门 → 时序冗余剔除 → 配额内按清晰度淘汰 → **配额保底回填** → 第一层兜底
  - **配额保底**：被曝光门拦下但仍保留可用细节（拉普拉斯方差达标）的帧，按清晰度回填到 `keep_per_window`，避免窗口塌成“每窗一帧”；低细节（模糊）帧不参与回填，仍由第一层兜底保证至少一帧
  - 窗口内首个合格帧无条件保留（时序锚点）
  - 两层显式 `forced_keep` 兜底：窗口全空时保留该窗口方差最高帧；全部窗口处理完后回填间隔超过 `window_size` 的区间
  - 输出 `metadata.csv`（含全部帧，含被剔除帧）、`filter_summary.json`（含 `strategyVersion` 与 `forcedKeeps`）、`filter_forced_keep.log`
- 新增 `FILTER_STRATEGY_VERSION`（当前为 2）并写入 `filter_summary.json`：任何改变筛选语义的改动都必须递增它，使下游与断点续跑能判断已有审计产物是否由同一套策略生成
- 新增 `SmartFrameSelection`（`frame_plan.rs`）：为过滤预留候选帧而超采样，并把采样率钳制到不超过源视频 FPS，避免请求高于源帧率而产生重复帧
- `QualityPreset` 增加 `enable_smart_filter` 与 `smart_filter_config`（Fast 2 / Balanced 3 / High 4 帧每窗口），`FrameFilterConfig` 派生 `Copy`，`QualityPreset` 保持 `Copy`，调用点无需迁移
- 接入 GUI 流水线与 `splatstudio extract` CLI：在既有 `PipelineStage::ExtractingFrames` 阶段内部完成过滤后处理，未新增或修改 `PipelineStage` 变体
- 透明视频按保留帧同步裁剪 Alpha Mask；审计文件保留在最终帧目录
- 新增依赖仅 `rayon`（纯 Rust、无系统依赖），用于并行计算每帧指标

## 原因

相邻视频帧重叠度通常很高，快速运动还会产生模糊帧。原实现按固定比例均匀抽帧，会把大量冗余帧与模糊帧一并送入 COLMAP，既增加匹配压力，也拉长 mapper 耗时。用户需求是“自动剔除运动太快导致模糊的照片，自动优选图片，而不是简单的间隔抽帧”。

设计上刻意避免全局按质量排序取 Top-N：下游 COLMAP 使用 `sequential_matcher --SequentialMatching.overlap 10`，依赖帧的时序邻域关系建立匹配图。全局排序会抽出时间上跳跃的帧，导致匹配图断裂、mapper 分块失败。因此筛选按连续窗口进行，并保留显式的 `forced_keep` 兜底来保证时序连续性。

### 关于曝光判定的一次重要修正

首版把曝光不可用等同于“**亮**”：统计 >250 的像素占比并设阈值 2%。这在真实场景里是错的——白布景实物扫描、雪景、过曝天空、白色产品背景都会轻易超过 2%，而这些帧对重建完全可用。实测（balanced 预设，各 68 帧输入）：

| 素材 | 修复前曝光拒绝 | 修复后曝光拒绝 | 修复后结果 |
|---|---|---|---|
| 白布景（95.7% 像素 ≥254，静止画面） | **61 / 68** | **0 / 68** | 静止画面按冗余正确保留每窗一帧 |
| 白布景 + 真实镜头运动（67.0% 像素 ≥254） | 旧阈值必然整段被拒（推断） | **0 / 68** | **30.9% 保留，填满配额，零兜底** |
| 白布景 + 物体移动（慢速 60 px/s，纹理物体） | 旧阈值必然整段被拒（推断） | **0 / 68** | **30.9% 保留，填满配额，零兜底** |
| 白布景 + 物体移动（快速 300 px/s，纹理物体） | 旧阈值必然整段被拒（推断） | **0 / 68** | **30.9% 保留，填满配额，零兜底** |
| 白布景 + 物体移动（纯色无纹理物体） | 旧阈值必然整段被拒（推断） | **0 / 68** | **30.9% 保留，填满配额，零兜底** |
| 纹理场景 + 镜头平移 | 0 | 0 | **30.9% 保留，填满配额，零兜底** |
| testsrc 合成图（10.6% ≥250） | 52 / 68 | 0 / 68 | — |

标注“推断”的行未用旧版本二进制复测（旧二进制已被覆盖），依据是旧规则在白色占比仅 10.6% 的素材上就已拒掉 52/68 帧。所有“白背景 + 物体移动”素材均已逐帧验证确实在运动（非静止画面），保留率均为 30.9% = 每窗口 3 帧的配额。

因此本 PR 将曝光改为“**真裁切 + 序列离群**”判定：绝对阈值由 0.02 校准到 0.55，判定改为 `≥254 / ≤1`，并在其上叠加“序列中位数 + 0.30 离群裕度”，只有明显异于同段素材的帧（闪光、对着灯拍）才算曝光异常。同时加入配额保底，避免任何单一规则把窗口压成“每窗一帧”。策略语义变化已通过 `FILTER_STRATEGY_VERSION` 递增到 2 标记。

## 实际测试

- `cargo test`：本 PR 分支 113 项全部通过（主干既有 103 项 + 本模块 10 项）
- `cargo clippy --all-targets -- -D warnings`：通过，无警告
- `cargo fmt --all -- --check`：通过
- 单元测试覆盖：
  - 模糊剔除（纹理底图 + 指定帧高斯模糊，断言 `blur` 且未被保留）
  - 曝光剔除（全白 PNG，断言过曝比例接近 1.0 且被剔除）
  - **白布景不被整段误拒**（白底 + 移动物体，断言曝光拒绝为 0 且保留量达到配额）
  - **曝光门配额保底**（整窗被曝光门拦下但细节充足，断言回填到配额且标记 `forced_keep`）
  - 冗余剔除（20 张相同图，断言保留帧数不超过 窗口数 × keep_per_window）
  - 时序连续性（断言保留帧索引严格单调递增，且相邻保留帧间隔不超过 `window_size`）
  - 指标正确性（噪声图拉普拉斯方差显著高于纯色图）
  - CSV 输出（`metadata.csv` 行数等于输入帧数 + 表头）
  - 策略版本写入审计产物
- 发布版二进制端到端：用本 PR 构建出的 `splatstudio.exe extract` 跑真实抽帧，确认 `filter_summary.json` 含 `strategyVersion`；白布景素材（静止、镜头运动、物体移动、纯色物体移动）曝光误拒均为 0，且有运动的素材一律填满配额（30.9%）
- 未运行 `npm lint` / `npm format` / mock 相关命令，仓库不存在这些命令
- **证据缺口**：尚未在真实长视频上做端到端 A/B 对比（耗时 / 注册率 / PSNR）。上表曝光数据来自合成素材；真实素材上曝光与冗余阈值的表现仍待验证，按项目约定此处明确声明缺口而不预估收益。

## 流水线覆盖率

- FFmpeg：抽帧仍走既有 CLI 与 `ProcessManager::run(ProcessSpec)`，滤镜、`-progress pipe:1` 与掩码分支未改动；智能筛选是抽帧之后的独立后处理步骤
- COLMAP：调用方式、`database.db` 与稀疏输出契约未改动；输入图像集合因筛选而减少
- Brush：调用与 `dataset/images` + `dataset/sparse/0` 结构未改动
- Gaussian PLY：`final.ply` 路径与文件名不变
- 兼容性：筛选后的保留帧仍为 `frame_%06d.{jpg,png}` 连续命名；`normalize_checkpoints` 的断点续跑校验仍按图像与 Mask 文件计数，未纳入 CSV/JSON/日志，不会被误判为帧

## UI 截图

不适用（本 PR 无界面改动；筛选结果为既有帧目录内容与审计文件）。

## 关联 Issue

无关联 Issue，未使用 `Closes`。

## 平台信息

- Windows 11 x64，Rust stable 1.98（x86_64-pc-windows-msvc）
- Node 24.9.0 / npm 10.9.8
- 本地引擎：FFmpeg / FFprobe、COLMAP 4.0.4、Brush CLI

## 已知限制

- `min_diff_score` 的冗余判定在窗口内以“上一张保留帧”为参考；静止画面（含静止相机）会正确地降到每窗一帧
- Alpha 输入的两项指标（曝光、拉普拉斯）均限定在 Mask 可见像素与其有效邻域内
- 该筛选会减少送入 COLMAP 的帧数，重建质量与耗时影响需要在真实素材上验证
